### PR TITLE
feat(open-bbcd): flow-map configurator — PR2 edit paths

### DIFF
--- a/open-bbcd/internal/flowmap/id.go
+++ b/open-bbcd/internal/flowmap/id.go
@@ -1,0 +1,51 @@
+package flowmap
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"strings"
+	"unicode"
+)
+
+// SlugifySkillName lowercases s, replaces runs of non-ASCII-alphanumeric
+// characters with single hyphens, and trims leading/trailing hyphens.
+// Returns "" if no usable characters remain — callers must reject that case.
+func SlugifySkillName(s string) string {
+	var b strings.Builder
+	prevHyphen := true // suppresses leading hyphens
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			prevHyphen = false
+		} else if unicode.IsSpace(r) || r == '-' || r == '_' {
+			if !prevHyphen {
+				b.WriteByte('-')
+				prevHyphen = true
+			}
+		}
+		// other runes are dropped
+	}
+	return strings.TrimRight(b.String(), "-")
+}
+
+// UniqueSkillID returns base if it is not in taken; otherwise appends "-<4-hex>"
+// using crypto/rand. Re-rolls on the (cosmically unlikely) chance of collision.
+func UniqueSkillID(base string, taken map[string]struct{}) string {
+	if _, exists := taken[base]; !exists {
+		return base
+	}
+	for attempts := 0; attempts < 8; attempts++ {
+		var buf [2]byte
+		if _, err := rand.Read(buf[:]); err != nil {
+			// crypto/rand should never fail on Linux; if it does, fall back
+			// to a deterministic suffix derived from base length.
+			return base + "-" + hex.EncodeToString([]byte{byte(len(base)), 0xa5})
+		}
+		candidate := base + "-" + hex.EncodeToString(buf[:])
+		if _, exists := taken[candidate]; !exists {
+			return candidate
+		}
+	}
+	// 8 collisions on a 16-bit suffix is extraordinary; surface a deterministic id.
+	return base + "-conflict"
+}

--- a/open-bbcd/internal/flowmap/id_test.go
+++ b/open-bbcd/internal/flowmap/id_test.go
@@ -1,0 +1,47 @@
+package flowmap
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSlugifySkillName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"Place Order", "place-order"},
+		{"  Trim me  ", "trim-me"},
+		{"Order #42!", "order-42"},
+		{"Send_email_alert", "send-email-alert"},
+		{"camelCase ID", "camelcase-id"},
+		{"Multiple   spaces", "multiple-spaces"},
+		{"---hyphens---", "hyphens"},
+		{"żółć", ""}, // non-ASCII collapses; caller guards empty
+	}
+	for _, tc := range tests {
+		got := SlugifySkillName(tc.in)
+		if got != tc.want {
+			t.Errorf("SlugifySkillName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestUniqueSkillID_NoCollision(t *testing.T) {
+	taken := map[string]struct{}{"foo": {}, "bar": {}}
+	got := UniqueSkillID("baz", taken)
+	if got != "baz" {
+		t.Errorf("UniqueSkillID = %q, want baz", got)
+	}
+}
+
+func TestUniqueSkillID_CollisionAppendsDiscriminator(t *testing.T) {
+	taken := map[string]struct{}{"foo": {}}
+	got := UniqueSkillID("foo", taken)
+	if !strings.HasPrefix(got, "foo-") || len(got) != len("foo-")+4 {
+		t.Errorf("UniqueSkillID = %q, want foo-<4-hex-chars>", got)
+	}
+	if _, exists := taken[got]; exists {
+		t.Errorf("UniqueSkillID returned an already-taken id: %q", got)
+	}
+}

--- a/open-bbcd/internal/flowmap/mermaid.go
+++ b/open-bbcd/internal/flowmap/mermaid.go
@@ -27,3 +27,14 @@ func validateWorkflowSkillRefs(mermaid string, skills map[string]struct{}) error
 	}
 	return nil
 }
+
+// WorkflowReferencesSkill returns true if the mermaid string declares any
+// id[<skill-id>] rectangle node whose label equals the given skill id.
+func WorkflowReferencesSkill(mermaid, skillID string) bool {
+	for _, m := range skillNodeRe.FindAllStringSubmatch(mermaid, -1) {
+		if m[2] == skillID {
+			return true
+		}
+	}
+	return false
+}

--- a/open-bbcd/internal/handler/api.go
+++ b/open-bbcd/internal/handler/api.go
@@ -76,6 +76,11 @@ func NewAPI(db *sql.DB, store storage.Storage, discoveryCfg config.DiscoveryConf
 	mux.HandleFunc("GET /agents/{id}/configure/skills/{skillId}", configuratorHandler.Skills)
 	mux.HandleFunc("GET /agents/{id}/configure/capabilities", configuratorHandler.Capabilities)
 	mux.HandleFunc("GET /agents/{id}/configure/capabilities/{capName}", configuratorHandler.Capabilities)
+	mux.HandleFunc("POST /agents/{id}/configure/flows/{flowId}/included", configuratorHandler.FlowIncluded)
+	mux.HandleFunc("GET /agents/{id}/configure/skills/new", configuratorHandler.SkillNew)
+	mux.HandleFunc("POST /agents/{id}/configure/skills", configuratorHandler.SkillCreate)
+	mux.HandleFunc("POST /agents/{id}/configure/skills/{skillId}", configuratorHandler.SkillUpdate)
+	mux.HandleFunc("DELETE /agents/{id}/configure/skills/{skillId}", configuratorHandler.SkillDelete)
 
 	mux.HandleFunc("GET /health", Health)
 	mux.HandleFunc("POST /agents", agentHandler.Create)

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -254,3 +254,47 @@ func (h *ConfiguratorHandler) saveConfig(ctx context.Context, agentID string, cf
 	}
 	return h.repo.UpdateFlowMapConfig(ctx, agentID, b)
 }
+
+// FlowIncluded toggles a flow's `included` boolean. Body: "included=true"
+// or "included=false". Responds with the updated flow_row HTML fragment so
+// htmx can swap the list row in place.
+func (h *ConfiguratorHandler) FlowIncluded(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+	included := r.FormValue("included") == "true"
+
+	agentID := r.PathValue("id")
+	flowID := r.PathValue("flowId")
+	cfg, err := h.loadConfig(r.Context(), agentID)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	idx := -1
+	for i := range cfg.Flows {
+		if cfg.Flows[i].ID == flowID {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		http.NotFound(w, r)
+		return
+	}
+	cfg.Flows[idx].Included = included
+
+	if err := h.saveConfig(r.Context(), agentID, cfg); err != nil {
+		Error(w, err)
+		return
+	}
+
+	// Re-render the flow row so htmx can swap it in place.
+	renderTemplate(w, h.flowsTmpl, "flow_row", map[string]any{
+		"AgentID":    agentID,
+		"Flow":       cfg.Flows[idx],
+		"SelectedID": "",
+	})
+}

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -402,6 +402,50 @@ func (h *ConfiguratorHandler) SkillCreate(w http.ResponseWriter, r *http.Request
 	})
 }
 
+// SkillDelete removes a custom skill. Discovered skills cannot be deleted
+// (409). Custom skills cannot be deleted while referenced by any flow's
+// workflow (409). On success returns 200 with an empty body so htmx can
+// remove the row in place.
+func (h *ConfiguratorHandler) SkillDelete(w http.ResponseWriter, r *http.Request) {
+	agentID := r.PathValue("id")
+	skillID := r.PathValue("skillId")
+	cfg, err := h.loadConfig(r.Context(), agentID)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	idx := -1
+	for i := range cfg.Skills {
+		if cfg.Skills[i].ID == skillID {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		http.NotFound(w, r)
+		return
+	}
+	if cfg.Skills[idx].Origin != "custom" {
+		Error(w, types.ErrSkillReferenced)
+		return
+	}
+	for _, f := range cfg.Flows {
+		if flowmap.WorkflowReferencesSkill(f.Workflow.Mermaid, skillID) {
+			Error(w, types.ErrSkillReferenced)
+			return
+		}
+	}
+
+	cfg.Skills = append(cfg.Skills[:idx], cfg.Skills[idx+1:]...)
+	if err := h.saveConfig(r.Context(), agentID, cfg); err != nil {
+		Error(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
 // SkillUpdate applies form values to an existing skill in place.
 func (h *ConfiguratorHandler) SkillUpdate(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -446,6 +446,24 @@ func (h *ConfiguratorHandler) SkillDelete(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusOK)
 }
 
+// SkillNew renders an empty skill_new_form for creating a custom skill.
+// The form's submit URL is /skills (no skillId), creating a new row
+// instead of updating an existing one.
+func (h *ConfiguratorHandler) SkillNew(w http.ResponseWriter, r *http.Request) {
+	agentID := r.PathValue("id")
+	cfg, err := h.loadConfig(r.Context(), agentID)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+	blank := types.Skill{Origin: "custom", Role: "read"}
+	renderTemplate(w, h.skillsTmpl, "skill_new_form", map[string]any{
+		"AgentID":      agentID,
+		"Skill":        blank,
+		"Capabilities": cfg.Capabilities,
+	})
+}
+
 // SkillUpdate applies form values to an existing skill in place.
 func (h *ConfiguratorHandler) SkillUpdate(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/DACdigital/OpenBBC/open-bbcd/internal/flowmap"
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
 	"github.com/yuin/goldmark"
 )
@@ -349,6 +350,56 @@ func parseSkillForm(r *http.Request, capabilities []types.Capability) (types.Ski
 		ProposedTool:  strings.TrimSpace(r.FormValue("proposed_tool")),
 		UserPhrases:   phrases,
 	}, nil
+}
+
+// SkillCreate adds a new custom skill from form values. The id is server-
+// assigned via SlugifySkillName + UniqueSkillID. Returns the rendered
+// skill_row partial so htmx can append it to the list.
+func (h *ConfiguratorHandler) SkillCreate(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+	agentID := r.PathValue("id")
+	cfg, err := h.loadConfig(r.Context(), agentID)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	parsed, err := parseSkillForm(r, cfg.Capabilities)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+	if parsed.Name == "" {
+		Error(w, types.ErrCustomSkillNameRequired)
+		return
+	}
+
+	slug := flowmap.SlugifySkillName(parsed.Name)
+	if slug == "" {
+		Error(w, types.ErrCustomSkillNameRequired)
+		return
+	}
+	taken := make(map[string]struct{}, len(cfg.Skills))
+	for _, s := range cfg.Skills {
+		taken[s.ID] = struct{}{}
+	}
+	parsed.ID = flowmap.UniqueSkillID(slug, taken)
+	parsed.Origin = "custom"
+
+	cfg.Skills = append(cfg.Skills, parsed)
+	if err := h.saveConfig(r.Context(), agentID, cfg); err != nil {
+		Error(w, err)
+		return
+	}
+
+	renderTemplate(w, h.skillsTmpl, "skill_row", map[string]any{
+		"AgentID":    agentID,
+		"Skill":      parsed,
+		"SelectedID": "",
+	})
 }
 
 // SkillUpdate applies form values to an existing skill in place.

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -13,18 +13,19 @@ import (
 	"github.com/yuin/goldmark"
 )
 
-// ConfigGetter is the narrow interface the configurator depends on.
-type ConfigGetter interface {
+// ConfigStore is the narrow interface the configurator depends on.
+type ConfigStore interface {
 	GetFlowMapConfig(ctx context.Context, agentID string) (cfg []byte, parseErr string, err error)
 	GetByID(ctx context.Context, id string) (*types.Agent, error)
+	UpdateFlowMapConfig(ctx context.Context, agentID string, cfg []byte) error
 }
 
 type ConfiguratorHandler struct {
-	repo                                    ConfigGetter
+	repo                                    ConfigStore
 	flowsTmpl, skillsTmpl, capabilitiesTmpl *template.Template
 }
 
-func NewConfiguratorHandler(repo ConfigGetter, webFS fs.FS) (*ConfiguratorHandler, error) {
+func NewConfiguratorHandler(repo ConfigStore, webFS fs.FS) (*ConfiguratorHandler, error) {
 	funcs := template.FuncMap{
 		"renderMarkdown": renderMarkdown,
 		"dict":           tplDict,
@@ -225,4 +226,31 @@ func tplDict(kv ...any) (map[string]any, error) {
 		m[key] = kv[i+1]
 	}
 	return m, nil
+}
+
+// loadConfig fetches the agent's flow_map_config and unmarshals into a
+// FlowMapConfig. Returns ErrNotFound if the agent does not exist or has no
+// config persisted (the configurator pages assume the wizard already ran).
+func (h *ConfiguratorHandler) loadConfig(ctx context.Context, agentID string) (types.FlowMapConfig, error) {
+	cfgBytes, _, err := h.repo.GetFlowMapConfig(ctx, agentID)
+	if err != nil {
+		return types.FlowMapConfig{}, err
+	}
+	if len(cfgBytes) == 0 {
+		return types.FlowMapConfig{}, types.ErrNotFound
+	}
+	var cfg types.FlowMapConfig
+	if err := json.Unmarshal(cfgBytes, &cfg); err != nil {
+		return types.FlowMapConfig{}, err
+	}
+	return cfg, nil
+}
+
+// saveConfig marshals cfg to JSON and writes it via the repository.
+func (h *ConfiguratorHandler) saveConfig(ctx context.Context, agentID string, cfg types.FlowMapConfig) error {
+	b, err := json.Marshal(cfg)
+	if err != nil {
+		return err
+	}
+	return h.repo.UpdateFlowMapConfig(ctx, agentID, b)
 }

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"html/template"
 	"io/fs"
 	"net/http"
+	"strings"
 
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
 	"github.com/yuin/goldmark"
@@ -296,5 +298,115 @@ func (h *ConfiguratorHandler) FlowIncluded(w http.ResponseWriter, r *http.Reques
 		"AgentID":    agentID,
 		"Flow":       cfg.Flows[idx],
 		"SelectedID": "",
+	})
+}
+
+// parseSkillForm reads form values shared by SkillUpdate and SkillCreate.
+// Validates role; clears capability_ref/external_note when external is the
+// other state. Splits user_phrases on newlines or commas.
+func parseSkillForm(r *http.Request, capabilities []types.Capability) (types.Skill, error) {
+	role := strings.TrimSpace(r.FormValue("role"))
+	if role != "read" && role != "write" {
+		return types.Skill{}, types.ErrInvalidSkillRole
+	}
+	external := r.FormValue("external") == "true"
+	cap := strings.TrimSpace(r.FormValue("capability"))
+	note := strings.TrimSpace(r.FormValue("external_note"))
+	if external {
+		cap = ""
+	} else {
+		note = ""
+		if cap != "" {
+			ok := false
+			for _, c := range capabilities {
+				if c.Name == cap {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				return types.Skill{}, fmt.Errorf("%w: capability %q not present in this agent's discovery snapshot",
+					types.ErrFlowMapInvalid, cap)
+			}
+		}
+	}
+
+	rawPhrases := r.FormValue("user_phrases")
+	var phrases []string
+	for _, line := range strings.FieldsFunc(rawPhrases, func(r rune) bool { return r == '\n' || r == ',' }) {
+		if s := strings.TrimSpace(line); s != "" {
+			phrases = append(phrases, s)
+		}
+	}
+
+	return types.Skill{
+		Name:          strings.TrimSpace(r.FormValue("name")),
+		Description:   strings.TrimSpace(r.FormValue("description")),
+		Role:          role,
+		CapabilityRef: cap,
+		External:      external,
+		ExternalNote:  note,
+		ProposedTool:  strings.TrimSpace(r.FormValue("proposed_tool")),
+		UserPhrases:   phrases,
+	}, nil
+}
+
+// SkillUpdate applies form values to an existing skill in place.
+func (h *ConfiguratorHandler) SkillUpdate(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid form", http.StatusBadRequest)
+		return
+	}
+	agentID := r.PathValue("id")
+	skillID := r.PathValue("skillId")
+	cfg, err := h.loadConfig(r.Context(), agentID)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
+	idx := -1
+	for i := range cfg.Skills {
+		if cfg.Skills[i].ID == skillID {
+			idx = i
+			break
+		}
+	}
+	if idx == -1 {
+		http.NotFound(w, r)
+		return
+	}
+
+	parsed, err := parseSkillForm(r, cfg.Capabilities)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+	if parsed.Name == "" {
+		Error(w, types.ErrCustomSkillNameRequired)
+		return
+	}
+
+	// Preserve immutable fields: id, origin, prose_md.
+	cur := &cfg.Skills[idx]
+	cur.Name = parsed.Name
+	cur.Description = parsed.Description
+	cur.Role = parsed.Role
+	cur.CapabilityRef = parsed.CapabilityRef
+	cur.External = parsed.External
+	cur.ExternalNote = parsed.ExternalNote
+	cur.ProposedTool = parsed.ProposedTool
+	cur.UserPhrases = parsed.UserPhrases
+
+	if err := h.saveConfig(r.Context(), agentID, cfg); err != nil {
+		Error(w, err)
+		return
+	}
+
+	// Re-render skill_detail so the htmx swap shows the saved state.
+	renderTemplate(w, h.skillsTmpl, "skill_detail", map[string]any{
+		"AgentID":      agentID,
+		"Skill":        *cur,
+		"Capabilities": cfg.Capabilities,
 	})
 }

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -356,3 +356,67 @@ func TestConfigurator_SkillCreate_NameRequired(t *testing.T) {
 		t.Errorf("status = %d, want 400", w.Code)
 	}
 }
+
+func TestConfigurator_SkillDelete_Custom_OK(t *testing.T) {
+	cfg := sampleConfig()
+	cfg.Skills = append(cfg.Skills, types.Skill{
+		ID: "custom-thing", Origin: "custom", Name: "Custom thing", Role: "write",
+		External: true,
+	})
+	store := &stubConfigStore{cfg: cfg}
+	h := newConfigHandler(t, store)
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/agents/abc/configure/skills/custom-thing", nil)
+	req.SetPathValue("id", "abc")
+	req.SetPathValue("skillId", "custom-thing")
+	w := httptest.NewRecorder()
+	h.SkillDelete(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	for _, s := range store.cfg.Skills {
+		if s.ID == "custom-thing" {
+			t.Error("custom-thing should have been removed")
+		}
+	}
+}
+
+func TestConfigurator_SkillDelete_Discovered_409(t *testing.T) {
+	store := &stubConfigStore{cfg: sampleConfig()}
+	h := newConfigHandler(t, store)
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/agents/abc/configure/skills/place-order", nil)
+	req.SetPathValue("id", "abc")
+	req.SetPathValue("skillId", "place-order")
+	w := httptest.NewRecorder()
+	h.SkillDelete(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409 (cannot delete discovered skill)", w.Code)
+	}
+}
+
+func TestConfigurator_SkillDelete_Referenced_409(t *testing.T) {
+	cfg := sampleConfig()
+	// Add a custom skill that is referenced by the existing flow's workflow.
+	cfg.Skills = append(cfg.Skills, types.Skill{
+		ID: "needed-by-flow", Origin: "custom", Name: "Needed", Role: "write",
+		External: true,
+	})
+	cfg.Flows[0].Workflow.Mermaid = "flowchart TD\n" +
+		"  start([start]) --> a[needed-by-flow]\n" +
+		"  a --> e([end])"
+	store := &stubConfigStore{cfg: cfg}
+	h := newConfigHandler(t, store)
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/agents/abc/configure/skills/needed-by-flow", nil)
+	req.SetPathValue("id", "abc")
+	req.SetPathValue("skillId", "needed-by-flow")
+	w := httptest.NewRecorder()
+	h.SkillDelete(w, req)
+	if w.Code != http.StatusConflict {
+		t.Errorf("status = %d, want 409 (skill referenced by flow workflow)", w.Code)
+	}
+}

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -128,3 +128,60 @@ func TestConfigurator_ParseError_ShowsErrorBanner(t *testing.T) {
 		t.Errorf("Parse error not surfaced")
 	}
 }
+
+func TestConfigurator_FlowIncluded_Toggle(t *testing.T) {
+	store := &stubConfigStore{cfg: sampleConfig()}
+	h := newConfigHandler(t, store)
+
+	// Toggle off
+	req := httptest.NewRequest(http.MethodPost,
+		"/agents/abc/configure/flows/place-order/included",
+		strings.NewReader("included=false"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", "abc")
+	req.SetPathValue("flowId", "place-order")
+	w := httptest.NewRecorder()
+	h.FlowIncluded(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	if store.cfg.Flows[0].Included {
+		t.Error("Flows[0].Included should be false after toggle")
+	}
+	// The response is an htmx-friendly fragment containing the updated row.
+	if !strings.Contains(w.Body.String(), "place-order") {
+		t.Errorf("response should re-render the flow row")
+	}
+
+	// Toggle back on.
+	req2 := httptest.NewRequest(http.MethodPost,
+		"/agents/abc/configure/flows/place-order/included",
+		strings.NewReader("included=true"))
+	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req2.SetPathValue("id", "abc")
+	req2.SetPathValue("flowId", "place-order")
+	w2 := httptest.NewRecorder()
+	h.FlowIncluded(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("status = %d", w2.Code)
+	}
+	if !store.cfg.Flows[0].Included {
+		t.Error("Flows[0].Included should be true after second toggle")
+	}
+}
+
+func TestConfigurator_FlowIncluded_UnknownFlow_404(t *testing.T) {
+	store := &stubConfigStore{cfg: sampleConfig()}
+	h := newConfigHandler(t, store)
+	req := httptest.NewRequest(http.MethodPost,
+		"/agents/abc/configure/flows/ghost/included",
+		strings.NewReader("included=false"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", "abc")
+	req.SetPathValue("flowId", "ghost")
+	w := httptest.NewRecorder()
+	h.FlowIncluded(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -183,5 +184,93 @@ func TestConfigurator_FlowIncluded_UnknownFlow_404(t *testing.T) {
 	h.FlowIncluded(w, req)
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestConfigurator_SkillUpdate_HappyPath(t *testing.T) {
+	store := &stubConfigStore{cfg: sampleConfig()}
+	h := newConfigHandler(t, store)
+
+	form := url.Values{
+		"name":          {"Place an order"},
+		"description":   {"Updated description"},
+		"role":          {"write"},
+		"capability":    {"orders"},
+		"proposed_tool": {"orders.create"},
+		"user_phrases":  {"check out\nplace order\nbuy"},
+		"external":      {"false"},
+	}
+	req := httptest.NewRequest(http.MethodPost,
+		"/agents/abc/configure/skills/place-order",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", "abc")
+	req.SetPathValue("skillId", "place-order")
+	w := httptest.NewRecorder()
+	h.SkillUpdate(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	got := store.cfg.Skills[0]
+	if got.Name != "Place an order" || got.Description != "Updated description" {
+		t.Errorf("metadata not saved: %+v", got)
+	}
+	if len(got.UserPhrases) != 3 || got.UserPhrases[0] != "check out" {
+		t.Errorf("user_phrases not split correctly: %+v", got.UserPhrases)
+	}
+	if got.External {
+		t.Error("External should be false")
+	}
+}
+
+func TestConfigurator_SkillUpdate_External(t *testing.T) {
+	store := &stubConfigStore{cfg: sampleConfig()}
+	h := newConfigHandler(t, store)
+
+	form := url.Values{
+		"name":          {"Send notification"},
+		"role":          {"write"},
+		"external":      {"true"},
+		"external_note": {"sends to webhook"},
+		"user_phrases":  {""},
+	}
+	req := httptest.NewRequest(http.MethodPost,
+		"/agents/abc/configure/skills/place-order",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", "abc")
+	req.SetPathValue("skillId", "place-order")
+	w := httptest.NewRecorder()
+	h.SkillUpdate(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	got := store.cfg.Skills[0]
+	if !got.External || got.ExternalNote != "sends to webhook" {
+		t.Errorf("External/Note not saved: %+v", got)
+	}
+	if got.CapabilityRef != "" {
+		t.Errorf("CapabilityRef should be cleared when external=true, got %q", got.CapabilityRef)
+	}
+}
+
+func TestConfigurator_SkillUpdate_InvalidRole(t *testing.T) {
+	store := &stubConfigStore{cfg: sampleConfig()}
+	h := newConfigHandler(t, store)
+
+	form := url.Values{
+		"name": {"Some skill"},
+		"role": {"banana"}, // invalid
+	}
+	req := httptest.NewRequest(http.MethodPost,
+		"/agents/abc/configure/skills/place-order",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", "abc")
+	req.SetPathValue("skillId", "place-order")
+	w := httptest.NewRecorder()
+	h.SkillUpdate(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
 	}
 }

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -13,14 +13,15 @@ import (
 	"github.com/DACdigital/OpenBBC/open-bbcd/web"
 )
 
-// stubConfigGetter returns a hardcoded FlowMapConfig as raw JSON.
-type stubConfigGetter struct {
+type stubConfigStore struct {
 	cfg      types.FlowMapConfig
 	getErr   error
 	parseErr string
+	updates  int
+	updateFn func(cfg []byte) error
 }
 
-func (s *stubConfigGetter) GetFlowMapConfig(ctx context.Context, agentID string) ([]byte, string, error) {
+func (s *stubConfigStore) GetFlowMapConfig(ctx context.Context, agentID string) ([]byte, string, error) {
 	if s.getErr != nil {
 		return nil, "", s.getErr
 	}
@@ -28,8 +29,21 @@ func (s *stubConfigGetter) GetFlowMapConfig(ctx context.Context, agentID string)
 	return b, s.parseErr, nil
 }
 
-func (s *stubConfigGetter) GetByID(ctx context.Context, id string) (*types.Agent, error) {
+func (s *stubConfigStore) GetByID(ctx context.Context, id string) (*types.Agent, error) {
 	return &types.Agent{ID: id, Name: s.cfg.Name, Status: "INITIALIZING"}, nil
+}
+
+func (s *stubConfigStore) UpdateFlowMapConfig(ctx context.Context, agentID string, cfg []byte) error {
+	s.updates++
+	if s.updateFn != nil {
+		return s.updateFn(cfg)
+	}
+	var decoded types.FlowMapConfig
+	if err := json.Unmarshal(cfg, &decoded); err != nil {
+		return err
+	}
+	s.cfg = decoded
+	return nil
 }
 
 func sampleConfig() types.FlowMapConfig {
@@ -49,7 +63,7 @@ func sampleConfig() types.FlowMapConfig {
 	}
 }
 
-func newConfigHandler(t *testing.T, getter handler.ConfigGetter) *handler.ConfiguratorHandler {
+func newConfigHandler(t *testing.T, getter handler.ConfigStore) *handler.ConfiguratorHandler {
 	t.Helper()
 	h, err := handler.NewConfiguratorHandler(getter, web.Assets)
 	if err != nil {
@@ -59,7 +73,7 @@ func newConfigHandler(t *testing.T, getter handler.ConfigGetter) *handler.Config
 }
 
 func TestConfigurator_FlowsTab_RendersFlowsList(t *testing.T) {
-	h := newConfigHandler(t, &stubConfigGetter{cfg: sampleConfig()})
+	h := newConfigHandler(t, &stubConfigStore{cfg: sampleConfig()})
 	req := httptest.NewRequest(http.MethodGet, "/agents/abc/configure/flows", nil)
 	req.SetPathValue("id", "abc")
 	w := httptest.NewRecorder()
@@ -73,7 +87,7 @@ func TestConfigurator_FlowsTab_RendersFlowsList(t *testing.T) {
 }
 
 func TestConfigurator_SkillsTab_ShowsSkillRow(t *testing.T) {
-	h := newConfigHandler(t, &stubConfigGetter{cfg: sampleConfig()})
+	h := newConfigHandler(t, &stubConfigStore{cfg: sampleConfig()})
 	req := httptest.NewRequest(http.MethodGet, "/agents/abc/configure/skills", nil)
 	req.SetPathValue("id", "abc")
 	w := httptest.NewRecorder()
@@ -87,7 +101,7 @@ func TestConfigurator_SkillsTab_ShowsSkillRow(t *testing.T) {
 }
 
 func TestConfigurator_CapabilitiesTab_IsReadOnly(t *testing.T) {
-	h := newConfigHandler(t, &stubConfigGetter{cfg: sampleConfig()})
+	h := newConfigHandler(t, &stubConfigStore{cfg: sampleConfig()})
 	req := httptest.NewRequest(http.MethodGet, "/agents/abc/configure/capabilities", nil)
 	req.SetPathValue("id", "abc")
 	w := httptest.NewRecorder()
@@ -102,7 +116,7 @@ func TestConfigurator_CapabilitiesTab_IsReadOnly(t *testing.T) {
 }
 
 func TestConfigurator_ParseError_ShowsErrorBanner(t *testing.T) {
-	h := newConfigHandler(t, &stubConfigGetter{cfg: sampleConfig(), parseErr: "missing tools-proposed.json"})
+	h := newConfigHandler(t, &stubConfigStore{cfg: sampleConfig(), parseErr: "missing tools-proposed.json"})
 	req := httptest.NewRequest(http.MethodGet, "/agents/abc/configure", nil)
 	req.SetPathValue("id", "abc")
 	w := httptest.NewRecorder()

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -274,3 +274,85 @@ func TestConfigurator_SkillUpdate_InvalidRole(t *testing.T) {
 		t.Errorf("status = %d, want 400", w.Code)
 	}
 }
+
+func TestConfigurator_SkillCreate_HappyPath(t *testing.T) {
+	store := &stubConfigStore{cfg: sampleConfig()}
+	h := newConfigHandler(t, store)
+
+	form := url.Values{
+		"name":          {"Send Email Alert"},
+		"description":   {"Notify the user via email"},
+		"role":          {"write"},
+		"external":      {"true"},
+		"external_note": {"sends through SMTP relay"},
+		"user_phrases":  {"send email\nemail me"},
+	}
+	req := httptest.NewRequest(http.MethodPost,
+		"/agents/abc/configure/skills",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", "abc")
+	w := httptest.NewRecorder()
+	h.SkillCreate(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+
+	if len(store.cfg.Skills) != 2 {
+		t.Fatalf("Skills len = %d, want 2", len(store.cfg.Skills))
+	}
+	created := store.cfg.Skills[1]
+	if created.ID != "send-email-alert" {
+		t.Errorf("created.ID = %q, want send-email-alert", created.ID)
+	}
+	if created.Origin != "custom" {
+		t.Errorf("created.Origin = %q, want custom", created.Origin)
+	}
+	if !created.External {
+		t.Error("External should be true")
+	}
+}
+
+func TestConfigurator_SkillCreate_NameCollision_GetsDiscriminator(t *testing.T) {
+	cfg := sampleConfig()
+	// Existing skill is "place-order"; force a collision by using the same name.
+	store := &stubConfigStore{cfg: cfg}
+	h := newConfigHandler(t, store)
+
+	form := url.Values{
+		"name":     {"Place Order"},
+		"role":     {"write"},
+		"external": {"true"},
+	}
+	req := httptest.NewRequest(http.MethodPost,
+		"/agents/abc/configure/skills",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", "abc")
+	w := httptest.NewRecorder()
+	h.SkillCreate(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	created := store.cfg.Skills[len(store.cfg.Skills)-1]
+	if !strings.HasPrefix(created.ID, "place-order-") || created.ID == "place-order" {
+		t.Errorf("collision id = %q, want place-order-<hex>", created.ID)
+	}
+}
+
+func TestConfigurator_SkillCreate_NameRequired(t *testing.T) {
+	store := &stubConfigStore{cfg: sampleConfig()}
+	h := newConfigHandler(t, store)
+
+	form := url.Values{"role": {"write"}, "external": {"true"}}
+	req := httptest.NewRequest(http.MethodPost,
+		"/agents/abc/configure/skills",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", "abc")
+	w := httptest.NewRecorder()
+	h.SkillCreate(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}

--- a/open-bbcd/internal/handler/handler.go
+++ b/open-bbcd/internal/handler/handler.go
@@ -34,13 +34,18 @@ func Error(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, types.ErrNotFound):
 		status = http.StatusNotFound
+	case errors.Is(err, types.ErrSkillReferenced):
+		status = http.StatusConflict
 	case errors.Is(err, types.ErrNameRequired),
 		errors.Is(err, types.ErrPromptRequired),
 		errors.Is(err, types.ErrAgentRequired),
 		errors.Is(err, types.ErrDiscoveryFileRequired),
 		errors.Is(err, types.ErrDiscoveryFileTooLarge),
 		errors.Is(err, types.ErrDiscoveryFileBadExtension),
-		errors.Is(err, types.ErrFlowMapInvalid):
+		errors.Is(err, types.ErrFlowMapInvalid),
+		errors.Is(err, types.ErrCapabilityReadOnly),
+		errors.Is(err, types.ErrInvalidSkillRole),
+		errors.Is(err, types.ErrCustomSkillNameRequired):
 		status = http.StatusBadRequest
 	}
 

--- a/open-bbcd/internal/types/errors.go
+++ b/open-bbcd/internal/types/errors.go
@@ -13,4 +13,9 @@ var (
 	ErrDiscoveryFileBadExtension = errors.New("discovery file must be a .zip")
 
 	ErrFlowMapInvalid = errors.New("flow-map archive is invalid")
+
+	ErrSkillReferenced         = errors.New("skill is referenced by a flow's workflow and cannot be deleted")
+	ErrCapabilityReadOnly      = errors.New("capabilities are read-only")
+	ErrInvalidSkillRole        = errors.New("skill role must be 'read' or 'write'")
+	ErrCustomSkillNameRequired = errors.New("custom skill name is required")
 )

--- a/open-bbcd/web/static/chip-input.js
+++ b/open-bbcd/web/static/chip-input.js
@@ -1,0 +1,84 @@
+// chip-input.js — turns <div data-chip-input> into a tag input.
+// Markup contract:
+//   <div class="chip-input" data-chip-input data-name="user_phrases" data-value="a,b,c"></div>
+// Renders chips, an inline text field, and a hidden input named data-name carrying
+// the current comma-joined value. Triggers a 'change' on the hidden input on every
+// add/remove so htmx form serialization picks up the latest value.
+
+(function () {
+  function init(el) {
+    if (el.dataset.chipReady === "1") return;
+    el.dataset.chipReady = "1";
+
+    const name = el.dataset.name || "phrases";
+    const initial = (el.dataset.value || "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    const hidden = document.createElement("input");
+    hidden.type = "hidden";
+    hidden.name = name;
+    el.appendChild(hidden);
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "chip-input-field";
+    input.placeholder = "type a phrase, press Enter";
+    el.appendChild(input);
+
+    let chips = [];
+
+    function sync() {
+      hidden.value = chips.join(",");
+      hidden.dispatchEvent(new Event("change", { bubbles: true }));
+      el.querySelectorAll(".chip").forEach((c) => c.remove());
+      chips.forEach((value, idx) => {
+        const span = document.createElement("span");
+        span.className = "chip";
+        span.textContent = value;
+        const x = document.createElement("button");
+        x.type = "button";
+        x.className = "chip-x";
+        x.textContent = "×";
+        x.onclick = () => {
+          chips.splice(idx, 1);
+          sync();
+        };
+        span.appendChild(x);
+        el.insertBefore(span, input);
+      });
+    }
+
+    function addFromInput() {
+      const v = input.value.trim();
+      if (v && !chips.includes(v)) {
+        chips.push(v);
+      }
+      input.value = "";
+      sync();
+    }
+
+    input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === ",") {
+        e.preventDefault();
+        addFromInput();
+      } else if (e.key === "Backspace" && input.value === "" && chips.length) {
+        chips.pop();
+        sync();
+      }
+    });
+    input.addEventListener("blur", addFromInput);
+
+    chips = initial;
+    sync();
+  }
+
+  function scan(root) {
+    (root || document).querySelectorAll("[data-chip-input]").forEach(init);
+  }
+
+  document.addEventListener("DOMContentLoaded", () => scan());
+  // Re-scan after htmx swaps so newly-rendered detail panes get wired.
+  document.body.addEventListener("htmx:afterSwap", (e) => scan(e.target));
+})();

--- a/open-bbcd/web/static/configurator.css
+++ b/open-bbcd/web/static/configurator.css
@@ -178,3 +178,89 @@
 .prose code { background: #21262d; padding: 1px 6px; border-radius: 3px; }
 .prose table { border-collapse: collapse; margin: 12px 0; }
 .prose th, .prose td { border: 1px solid #30363d; padding: 6px 10px; }
+
+.chip-input {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  padding: 6px;
+  background: #0d1117;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  min-height: 36px;
+}
+
+.chip-input-field {
+  flex: 1;
+  min-width: 120px;
+  background: transparent;
+  color: #e6edf3;
+  border: none;
+  outline: none;
+  font-size: 13px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px 2px 8px;
+  background: #21262d;
+  border-radius: 12px;
+  font-size: 12px;
+  color: #c9d1d9;
+}
+
+.chip-x {
+  background: transparent;
+  border: none;
+  color: #8b949e;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.chip-x:hover { color: #f85149; }
+
+/* Form-specific styles for the skill detail edit form. */
+.config-form { display: flex; flex-direction: column; gap: 12px; max-width: 640px; }
+.config-form label { display: flex; flex-direction: column; gap: 4px; font-size: 13px; color: #8b949e; }
+.config-form input[type=text],
+.config-form textarea,
+.config-form select {
+  background: #0d1117;
+  border: 1px solid #30363d;
+  color: #e6edf3;
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 13px;
+  font-family: inherit;
+}
+.config-form textarea { resize: vertical; min-height: 80px; }
+.config-form .form-row { display: flex; gap: 12px; align-items: flex-end; }
+.config-form .form-row > * { flex: 1; }
+.config-form .form-actions { display: flex; gap: 8px; margin-top: 8px; }
+.config-form-saved { color: #2ea043; font-size: 12px; opacity: 0; transition: opacity .2s; }
+.config-form-saved.show { opacity: 1; }
+
+.skill-add-trigger {
+  margin: 12px;
+  padding: 8px 12px;
+  background: #1f6feb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.skill-add-trigger:hover { background: #388bfd; }
+
+.danger-button {
+  background: #21262d;
+  color: #f85149;
+  border: 1px solid #30363d;
+}
+.danger-button:hover { background: #2d1418; border-color: #f85149; }

--- a/open-bbcd/web/templates/configurator/partials.html
+++ b/open-bbcd/web/templates/configurator/partials.html
@@ -1,10 +1,17 @@
 {{define "flow_row"}}
-<a href="/agents/{{.AgentID}}/configure/flows/{{.Flow.ID}}"
-   class="config-list-row {{if and .SelectedID (eq .SelectedID .Flow.ID)}}selected{{end}}">
-  <span class="config-list-row-icon">{{if .Flow.Included}}☑{{else}}☐{{end}}</span>
-  <span class="config-list-row-name">{{.Flow.ID}}</span>
-  <span class="config-list-row-meta">{{len .Flow.Workflow.Layout}} nodes</span>
-</a>
+<div id="flow-row-{{.Flow.ID}}" class="config-list-row {{if and .SelectedID (eq .SelectedID .Flow.ID)}}selected{{end}}">
+  <input type="checkbox" class="config-list-row-toggle"
+         {{if .Flow.Included}}checked{{end}}
+         hx-post="/agents/{{.AgentID}}/configure/flows/{{.Flow.ID}}/included"
+         hx-trigger="change"
+         hx-vals='js:{included: event.target.checked}'
+         hx-target="#flow-row-{{.Flow.ID}}"
+         hx-swap="outerHTML">
+  <a href="/agents/{{.AgentID}}/configure/flows/{{.Flow.ID}}" class="config-list-row-link">
+    <span class="config-list-row-name">{{.Flow.ID}}</span>
+    <span class="config-list-row-meta">{{len .Flow.Workflow.Layout}} nodes</span>
+  </a>
+</div>
 {{end}}
 
 {{define "flow_detail"}}

--- a/open-bbcd/web/templates/configurator/partials.html
+++ b/open-bbcd/web/templates/configurator/partials.html
@@ -48,15 +48,70 @@
 {{end}}
 
 {{define "skill_row"}}
-<a href="/agents/{{.AgentID}}/configure/skills/{{.Skill.ID}}"
-   class="config-list-row {{if and .SelectedID (eq .SelectedID .Skill.ID)}}selected{{end}}">
-  <span class="config-list-row-name">{{.Skill.ID}}</span>
-  <span class="config-list-row-meta">
-    <span class="badge badge-{{.Skill.Origin}}">{{.Skill.Origin}}</span>
-    {{if .Skill.External}}<span class="badge">external</span>{{else}}<span class="muted">{{.Skill.CapabilityRef}}</span>{{end}}
-    <code>{{.Skill.ProposedTool}}</code>
-  </span>
-</a>
+<div id="skill-row-{{.Skill.ID}}">
+  <a href="/agents/{{.AgentID}}/configure/skills/{{.Skill.ID}}"
+     class="config-list-row {{if and .SelectedID (eq .SelectedID .Skill.ID)}}selected{{end}}">
+    <span class="config-list-row-name">{{.Skill.ID}}</span>
+    <span class="config-list-row-meta">
+      <span class="badge badge-{{.Skill.Origin}}">{{.Skill.Origin}}</span>
+      {{if .Skill.External}}<span class="badge">external</span>{{else}}<span class="muted">{{.Skill.CapabilityRef}}</span>{{end}}
+      <code>{{.Skill.ProposedTool}}</code>
+    </span>
+  </a>
+</div>
+{{end}}
+
+{{define "skill_form_fields"}}
+<input type="hidden" name="agent_id" value="{{.AgentID}}">
+
+<label>Name
+  <input type="text" name="name" value="{{.Skill.Name}}" required>
+</label>
+
+<label>Description
+  <textarea name="description" rows="2">{{.Skill.Description}}</textarea>
+</label>
+
+<div class="form-row">
+  <label>Role
+    <select name="role">
+      <option value="read"  {{if eq .Skill.Role "read"}}selected{{end}}>read</option>
+      <option value="write" {{if eq .Skill.Role "write"}}selected{{end}}>write</option>
+    </select>
+  </label>
+  <label>Proposed tool
+    <input type="text" name="proposed_tool" value="{{.Skill.ProposedTool}}" placeholder="e.g. orders.create">
+  </label>
+</div>
+
+<label>User phrases
+  <div class="chip-input"
+       data-chip-input
+       data-name="user_phrases"
+       data-value="{{range $i, $p := .Skill.UserPhrases}}{{if $i}},{{end}}{{$p}}{{end}}"></div>
+</label>
+
+<label>Capability
+  <select name="capability"
+          hx-on:change="
+            const isExt = this.value === '__external__';
+            this.form.querySelector('[name=external]').value = isExt ? 'true' : 'false';
+            this.form.querySelector('.external-note-row').style.display = isExt ? '' : 'none';
+          ">
+    {{range .Capabilities}}
+    <option value="{{.Name}}" {{if and (not $.Skill.External) (eq .Name $.Skill.CapabilityRef)}}selected{{end}}>{{.Name}}</option>
+    {{end}}
+    <option value="__external__" {{if .Skill.External}}selected{{end}}>External (no discovered capability)</option>
+  </select>
+</label>
+
+<input type="hidden" name="external" value="{{if .Skill.External}}true{{else}}false{{end}}">
+
+<div class="external-note-row" style="{{if not .Skill.External}}display:none{{end}}">
+  <label>External note
+    <textarea name="external_note" rows="2" placeholder="why this skill has no discovered capability">{{.Skill.ExternalNote}}</textarea>
+  </label>
+</div>
 {{end}}
 
 {{define "skill_detail"}}
@@ -64,16 +119,29 @@
   <h2>{{.Skill.Name}}</h2>
   <p class="config-detail-id"><code>{{.Skill.ID}}</code> · <span class="badge badge-{{.Skill.Origin}}">{{.Skill.Origin}}</span></p>
 
-  <div class="config-section">
-    <h3>Metadata</h3>
-    <dl class="config-meta">
-      <dt>Description</dt>   <dd>{{.Skill.Description}}</dd>
-      <dt>Role</dt>          <dd>{{.Skill.Role}}</dd>
-      <dt>User phrases</dt>  <dd>{{range .Skill.UserPhrases}}<span class="chip">{{.}}</span>{{end}}</dd>
-      <dt>Capability</dt>    <dd>{{if .Skill.External}}external{{else}}<a href="/agents/{{.AgentID}}/configure/capabilities/{{.Skill.CapabilityRef}}">{{.Skill.CapabilityRef}}</a>{{end}}</dd>
-      <dt>Proposed tool</dt> <dd><code>{{.Skill.ProposedTool}}</code></dd>
-    </dl>
-  </div>
+  <form class="config-form"
+        hx-post="/agents/{{.AgentID}}/configure/skills/{{.Skill.ID}}"
+        hx-target="closest .config-detail"
+        hx-swap="outerHTML"
+        hx-indicator=".config-form-saved">
+    {{template "skill_form_fields" (dict
+      "AgentID"     .AgentID
+      "Skill"       .Skill
+      "Capabilities" .Capabilities)}}
+
+    <div class="form-actions">
+      <button type="submit" class="btn-primary">Save</button>
+      {{if eq .Skill.Origin "custom"}}
+      <button type="button"
+              class="btn-secondary danger-button"
+              hx-delete="/agents/{{.AgentID}}/configure/skills/{{.Skill.ID}}"
+              hx-target="#skill-row-{{.Skill.ID}}"
+              hx-swap="delete"
+              hx-confirm="Delete this custom skill?">Delete</button>
+      {{end}}
+      <span class="config-form-saved">Saved</span>
+    </div>
+  </form>
 
   {{if .Skill.ProseMD}}
   <div class="config-section">
@@ -81,6 +149,29 @@
     <div class="prose">{{renderMarkdown .Skill.ProseMD}}</div>
   </div>
   {{end}}
+</div>
+{{end}}
+
+{{define "skill_new_form"}}
+<div class="config-detail">
+  <h2>New custom skill</h2>
+  <p class="config-detail-id">A new id will be generated from the name.</p>
+
+  <form class="config-form"
+        hx-post="/agents/{{.AgentID}}/configure/skills"
+        hx-target="#skill-list-rows"
+        hx-swap="beforeend"
+        hx-indicator=".config-form-saved">
+    {{template "skill_form_fields" (dict
+      "AgentID"     .AgentID
+      "Skill"       .Skill
+      "Capabilities" .Capabilities)}}
+
+    <div class="form-actions">
+      <button type="submit" class="btn-primary">Create</button>
+      <span class="config-form-saved">Created</span>
+    </div>
+  </form>
 </div>
 {{end}}
 

--- a/open-bbcd/web/templates/configurator/skills.html
+++ b/open-bbcd/web/templates/configurator/skills.html
@@ -2,17 +2,23 @@
 <div class="config-two-pane">
   <aside class="config-list">
     <div class="config-list-header">Skills ({{len .Config.Skills}})</div>
-    {{range .Config.Skills}}
-      {{template "skill_row" (dict "AgentID" $.AgentID "Skill" . "SelectedID" (selectedSkillID $.SelectedSkill))}}
-    {{else}}
-      <p class="empty-state">No skills in this discovery snapshot.</p>
-    {{end}}
+    <div id="skill-list-rows">
+      {{range .Config.Skills}}
+        {{template "skill_row" (dict "AgentID" $.AgentID "Skill" . "SelectedID" (selectedSkillID $.SelectedSkill))}}
+      {{else}}
+        <p class="empty-state">No skills in this discovery snapshot.</p>
+      {{end}}
+    </div>
+    <button class="skill-add-trigger"
+            hx-get="/agents/{{.AgentID}}/configure/skills/new"
+            hx-target=".config-detail-pane"
+            hx-swap="innerHTML">+ Add skill</button>
   </aside>
   <main class="config-detail-pane">
     {{if .SelectedSkill}}
-      {{template "skill_detail" (dict "AgentID" .AgentID "Skill" .SelectedSkill)}}
+      {{template "skill_detail" (dict "AgentID" .AgentID "Skill" .SelectedSkill "Capabilities" .Config.Capabilities)}}
     {{else}}
-      <p class="config-detail-empty">Select a skill on the left.</p>
+      <p class="config-detail-empty">Select a skill on the left or click + Add skill.</p>
     {{end}}
   </main>
 </div>

--- a/open-bbcd/web/templates/layout.html
+++ b/open-bbcd/web/templates/layout.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>open-bbcd</title>
   <script src="/static/htmx.min.js"></script>
+  <script defer src="/static/chip-input.js"></script>
   <style>
     *{box-sizing:border-box;margin:0;padding:0}
     body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0f1117;color:#e6edf3;height:100vh;display:flex}


### PR DESCRIPTION
## Summary

PR2 makes everything except the workflow editor interactive. Builds on PR1 (#16).

- **Flow include/exclude toggle** — htmx checkbox in the flow row; swaps the row in place on toggle.
- **Skill update form** — every editable field (name, description, role, user phrases, proposed tool, capability binding, external mode + note) persists to `flow_map_config` JSONB. Role validation (`read|write`); capability must exist in the agent's snapshot.
- **Custom skill creation** — server-assigned id via `SlugifySkillName` + `UniqueSkillID` (4-hex collision discriminator). New rows render via htmx `beforeend` append.
- **Custom skill deletion** — gated: `origin=custom` AND no flow's workflow references the skill (otherwise 409).
- **Capabilities tab unchanged** — still read-only.
- **Chip-input widget** (~80 LoC vanilla JS) for `user_phrases`. Re-scans after htmx swaps.

Spec: `docs/superpowers/specs/2026-05-07-flow-map-configurator-design.md`
Plan: `docs/superpowers/plans/2026-05-08-flow-map-configurator-pr2.md`

## What's in the diff

- 4 new sentinel errors (`ErrSkillReferenced` → 409; the rest → 400) wired into `handler.Error`
- `internal/flowmap/id.go` — `SlugifySkillName` + `UniqueSkillID` (TDD)
- `internal/flowmap/mermaid.go` — exported `WorkflowReferencesSkill` for the delete-gate check
- `ConfigGetter` widened to `ConfigStore` (adds `UpdateFlowMapConfig`); private `loadConfig`/`saveConfig` helpers
- 5 new handler methods: `FlowIncluded`, `SkillUpdate`, `SkillCreate`, `SkillDelete`, `SkillNew`
- Templates: `skill_detail` rewritten as a form; new `skill_form_fields` shared partial; new `skill_new_form` partial; `skill_row` wrapped in stable-id div for htmx delete-swap; "+ Add skill" affordance
- `web/static/chip-input.js` + extended `configurator.css` (chip + form styles)
- 5 new routes registered in `api.go`

## Test plan

- [x] `cd open-bbcd && go test -race ./...` — all packages green (15 configurator tests, 4 flowmap tests, 3 id tests)
- [x] `cd open-bbcd && go vet ./...` — clean
- [x] Smoke test against real DB:
  - [x] Flow toggle on/off persists to JSONB
  - [x] Skill update saves all fields; user_phrases split correctly; invalid role → 400
  - [x] Create custom skill → id `send-email`, origin `custom`
  - [x] Collision → discriminator `send-email-e342`
  - [x] Delete discovered → 409
  - [x] Delete custom → 200 + skill removed

## Notes for reviewers

- 10 commits on the branch, each independently reviewable.
- The chip-input widget is small enough to read in one pass; uses `htmx:afterSwap` to re-init after detail-pane swaps.
- Last-write-wins concurrency model (read-modify-write on the JSONB blob) — accepted per the spec.
- PR3 (Drawflow workflow editor) and PR4 (finalize + YAML download) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)