### PR TITLE
fix(marketplace): point flow-map-compiler ref to main

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
         "source": "git-subdir",
         "url": "https://github.com/DACdigital/OpenBBC.git",
         "path": "bbc-discovery/flow-map-compiler",
-        "ref": "feat/flow-map-skill"
+        "ref": "main"
       },
       "description": "Compile a frontend repo into a .flow-map/ agent wiki — flows, capabilities, proposed MCP tools.",
       "category": "discovery",


### PR DESCRIPTION
## Summary

The marketplace manifest pinned the `flow-map-compiler` plugin to `ref: "feat/flow-map-skill"` — that branch was merged + deleted a while back. Anyone installing the plugin via this marketplace was hitting a dead ref.

Switching to `main` so installs pull the current published version of the skill.

## Test plan

- [ ] `cat .claude-plugin/marketplace.json | grep ref` → `"ref": "main"`
- [ ] Plugin install via this marketplace fetches `bbc-discovery/flow-map-compiler/` at HEAD of main

🤖 Generated with [Claude Code](https://claude.com/claude-code)