### PR TITLE
feat(open-bbcd): structured logging + UNIQUE constraint on parent_version_id

### DIFF
--- a/open-bbcd/cmd/open-bbcd/main.go
+++ b/open-bbcd/cmd/open-bbcd/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -28,29 +28,34 @@ func main() {
 }
 
 func run() error {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
 	cfg, err := config.Load()
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	log.Printf("connecting to database...")
+	logger.Info("connecting to database")
 	db, err := database.NewPostgres(cfg.Database.URL)
 	if err != nil {
 		return fmt.Errorf("connect to database: %w", err)
 	}
 	defer db.Close()
-	log.Printf("database connected")
+	logger.Info("database connected")
 
 	store, err := storage.NewLocalDisk(cfg.Discovery.StorageDir)
 	if err != nil {
 		return fmt.Errorf("init storage: %w", err)
 	}
-	log.Printf("discovery storage rooted at %s", cfg.Discovery.StorageDir)
+	logger.Info("discovery storage rooted", slog.String("dir", cfg.Discovery.StorageDir))
 
 	addr := fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port)
 	server := &http.Server{
 		Addr:         addr,
-		Handler:      handler.NewAPI(db, store, cfg.Discovery),
+		Handler:      handler.NewAPI(db, store, cfg.Discovery, logger),
 		ReadTimeout:  handler.ReadTimeout,
 		WriteTimeout: handler.WriteTimeout,
 		IdleTimeout:  handler.IdleTimeout,
@@ -60,14 +65,15 @@ func run() error {
 	signal.Notify(done, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
-		log.Printf("open-bbcd listening on %s", addr)
+		logger.Info("open-bbcd listening", slog.String("addr", addr))
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("server error: %v", err)
+			logger.Error("server error", slog.Any("error", err))
+			os.Exit(1)
 		}
 	}()
 
 	<-done
-	log.Printf("shutting down...")
+	logger.Info("shutting down")
 
 	ctx, cancel := context.WithTimeout(context.Background(), ShutdownTimeout)
 	defer cancel()

--- a/open-bbcd/internal/handler/api.go
+++ b/open-bbcd/internal/handler/api.go
@@ -3,8 +3,9 @@ package handler
 import (
 	"database/sql"
 	"io/fs"
-	"log"
+	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/config"
@@ -21,30 +22,35 @@ const (
 	IdleTimeout  = 60 * time.Second
 )
 
-func NewAPI(db *sql.DB, store storage.Storage, discoveryCfg config.DiscoveryConfig) http.Handler {
+func NewAPI(db *sql.DB, store storage.Storage, discoveryCfg config.DiscoveryConfig, logger *slog.Logger) http.Handler {
+	fatal := func(msg string, err error) {
+		logger.Error(msg, slog.Any("error", err))
+		os.Exit(1)
+	}
+
 	agentRepo := repository.NewAgentRepository(db)
 	resourceRepo := repository.NewResourceRepository(db)
 
 	// Load wizard schema from embedded FS.
 	schemaBytes, err := web.Assets.ReadFile("schemas/wizard-v1.yaml")
 	if err != nil {
-		log.Fatalf("load wizard schema: %v", err)
+		fatal("load wizard schema", err)
 	}
 	var schema types.WizardSchema
 	if err := yaml.Unmarshal(schemaBytes, &schema); err != nil {
-		log.Fatalf("parse wizard schema: %v", err)
+		fatal("parse wizard schema", err)
 	}
 
-	uiHandler, err := NewUIHandler(agentRepo, &schema, web.Assets)
+	uiHandler, err := NewUIHandler(agentRepo, &schema, web.Assets, logger)
 	if err != nil {
-		log.Fatalf("init UI handler: %v", err)
+		fatal("init UI handler", err)
 	}
 	maxUploadBytes := int64(discoveryCfg.MaxUploadMB) << 20
-	wizardHandler := NewWizardHandler(agentRepo, &schema, store, maxUploadBytes)
+	wizardHandler := NewWizardHandler(agentRepo, &schema, store, maxUploadBytes, logger)
 
 	configuratorHandler, err := NewConfiguratorHandler(agentRepo, web.Assets)
 	if err != nil {
-		log.Fatalf("init configurator handler: %v", err)
+		fatal("init configurator handler", err)
 	}
 
 	agentHandler := NewAgentHandler(agentRepo)
@@ -54,7 +60,7 @@ func NewAPI(db *sql.DB, store storage.Storage, discoveryCfg config.DiscoveryConf
 
 	staticFS, err := fs.Sub(web.Assets, "static")
 	if err != nil {
-		log.Fatalf("sub static FS: %v", err)
+		fatal("sub static FS", err)
 	}
 	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
 
@@ -94,5 +100,5 @@ func NewAPI(db *sql.DB, store storage.Storage, discoveryCfg config.DiscoveryConf
 	mux.HandleFunc("GET /resources/{id}", resourceHandler.Get)
 	mux.HandleFunc("GET /agents/{agent_id}/resources", resourceHandler.ListByAgent)
 
-	return mux
+	return RequestLogger(logger, mux)
 }

--- a/open-bbcd/internal/handler/middleware.go
+++ b/open-bbcd/internal/handler/middleware.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// responseRecorder wraps ResponseWriter to capture the written status code.
+type responseRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *responseRecorder) WriteHeader(status int) {
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
+}
+
+// RequestLogger is HTTP middleware that logs every request after it completes.
+func RequestLogger(logger *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+
+		next.ServeHTTP(rw, r)
+
+		level := slog.LevelInfo
+		if rw.status >= 500 {
+			level = slog.LevelError
+		} else if rw.status >= 400 {
+			level = slog.LevelWarn
+		}
+
+		logger.Log(r.Context(), level, "request",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", rw.status),
+			slog.Int64("duration_ms", time.Since(start).Milliseconds()),
+			slog.String("remote_addr", r.RemoteAddr),
+		)
+	})
+}

--- a/open-bbcd/internal/handler/testhelpers_test.go
+++ b/open-bbcd/internal/handler/testhelpers_test.go
@@ -1,0 +1,11 @@
+package handler
+
+import (
+	"io"
+	"log/slog"
+)
+
+// testLogger returns a slog.Logger that discards output, suitable for tests.
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}

--- a/open-bbcd/internal/handler/ui.go
+++ b/open-bbcd/internal/handler/ui.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"html/template"
 	"io/fs"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -18,12 +18,13 @@ type GroupedAgentRepository interface {
 }
 
 type UIHandler struct {
-	agentRepo       GroupedAgentRepository
-	schema          *types.WizardSchema
-	agentsTmpl      *template.Template
+	agentRepo         GroupedAgentRepository
+	schema            *types.WizardSchema
+	logger            *slog.Logger
+	agentsTmpl        *template.Template
 	agentVersionsTmpl *template.Template
-	wizardTmpl      *template.Template
-	stepTmpl        *template.Template
+	wizardTmpl        *template.Template
+	stepTmpl          *template.Template
 }
 
 func statusClass(status string) string {
@@ -39,7 +40,7 @@ func statusClass(status string) string {
 	}
 }
 
-func NewUIHandler(agentRepo GroupedAgentRepository, schema *types.WizardSchema, webFS fs.FS) (*UIHandler, error) {
+func NewUIHandler(agentRepo GroupedAgentRepository, schema *types.WizardSchema, webFS fs.FS, logger *slog.Logger) (*UIHandler, error) {
 	funcs := template.FuncMap{
 		"statusClass": statusClass,
 		"add":         func(a, b int) int { return a + b },
@@ -81,6 +82,7 @@ func NewUIHandler(agentRepo GroupedAgentRepository, schema *types.WizardSchema, 
 	return &UIHandler{
 		agentRepo:         agentRepo,
 		schema:            schema,
+		logger:            logger,
 		agentsTmpl:        agentsTmpl,
 		agentVersionsTmpl: agentVersionsTmpl,
 		wizardTmpl:        wizardTmpl,
@@ -92,7 +94,7 @@ func NewUIHandler(agentRepo GroupedAgentRepository, schema *types.WizardSchema, 
 func renderTemplate(w http.ResponseWriter, tmpl *template.Template, name string, data any) {
 	var buf bytes.Buffer
 	if err := tmpl.ExecuteTemplate(&buf, name, data); err != nil {
-		log.Printf("template %q error: %v", name, err)
+		slog.Error("template execution failed", slog.String("template", name), slog.Any("error", err))
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}

--- a/open-bbcd/internal/handler/wizard.go
+++ b/open-bbcd/internal/handler/wizard.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -25,14 +25,16 @@ type WizardHandler struct {
 	schema         *types.WizardSchema
 	store          storage.Storage
 	maxUploadBytes int64
+	logger         *slog.Logger
 }
 
-func NewWizardHandler(agentRepo WizardAgentRepository, schema *types.WizardSchema, store storage.Storage, maxUploadBytes int64) *WizardHandler {
+func NewWizardHandler(agentRepo WizardAgentRepository, schema *types.WizardSchema, store storage.Storage, maxUploadBytes int64, logger *slog.Logger) *WizardHandler {
 	return &WizardHandler{
 		agentRepo:      agentRepo,
 		schema:         schema,
 		store:          store,
 		maxUploadBytes: maxUploadBytes,
+		logger:         logger,
 	}
 }
 
@@ -75,7 +77,7 @@ func (h *WizardHandler) Submit(w http.ResponseWriter, r *http.Request) {
 			b, err := io.ReadAll(file)
 			file.Close()
 			if err != nil {
-				log.Printf("wizard: read upload: %v", err)
+				h.logger.Error("wizard: read upload", slog.Any("error", err))
 				http.Error(w, "failed to read upload", http.StatusInternalServerError)
 				return
 			}
@@ -83,7 +85,7 @@ func (h *WizardHandler) Submit(w http.ResponseWriter, r *http.Request) {
 
 			discoveryKey = agentID + ".zip"
 			if err := h.store.Put(r.Context(), discoveryKey, bytes.NewReader(zipBytes)); err != nil {
-				log.Printf("wizard: storage.Put %s: %v", discoveryKey, err)
+				h.logger.Error("wizard: storage.Put", slog.String("key", discoveryKey), slog.Any("error", err))
 				http.Error(w, "failed to save discovery file", http.StatusInternalServerError)
 				return
 			}
@@ -117,7 +119,7 @@ func (h *WizardHandler) Submit(w http.ResponseWriter, r *http.Request) {
 	} else {
 		b, err := json.Marshal(cfg)
 		if err != nil {
-			log.Printf("wizard: marshal flow_map_config: %v", err)
+			h.logger.Error("wizard: marshal flow_map_config", slog.Any("error", err))
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
@@ -133,9 +135,9 @@ func (h *WizardHandler) Submit(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		if discoveryKey != "" {
-			log.Printf("wizard: orphan discovery file %s after insert failure: %v", discoveryKey, err)
+			h.logger.Error("wizard: orphan discovery file after insert failure", slog.String("key", discoveryKey), slog.Any("error", err))
 		} else {
-			log.Printf("wizard: CreateFromWizard: %v", err)
+			h.logger.Error("wizard: CreateFromWizard", slog.Any("error", err))
 		}
 		Error(w, err)
 		return

--- a/open-bbcd/internal/handler/wizard_test.go
+++ b/open-bbcd/internal/handler/wizard_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"log"
+	"log/slog"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -73,7 +73,7 @@ func newTestWizardHandler(t *testing.T, repo WizardAgentRepository, store storag
 	if err := yaml.Unmarshal([]byte(wizardTestSchema), &schema); err != nil {
 		t.Fatalf("parse schema: %v", err)
 	}
-	return NewWizardHandler(repo, &schema, store, testMaxUploadBytes)
+	return NewWizardHandler(repo, &schema, store, testMaxUploadBytes, testLogger())
 }
 
 // buildWizardForm returns a multipart body with the given text fields and an
@@ -227,7 +227,7 @@ func TestWizardHandler_Submit_TooLarge(t *testing.T) {
 		t.Fatalf("parse schema: %v", err)
 	}
 	// Tiny cap so a small body trips the pre-check.
-	h := NewWizardHandler(repo, &schema, store, 16)
+	h := NewWizardHandler(repo, &schema, store, 16, testLogger())
 
 	body, ct := buildWizardForm(t,
 		map[string]string{"name": "X", "scope": "Y"},
@@ -279,9 +279,7 @@ func TestWizardHandler_Submit_StorageFails(t *testing.T) {
 
 func TestWizardHandler_Submit_RepoFailLogsOrphan(t *testing.T) {
 	var logBuf bytes.Buffer
-	origOut := log.Writer()
-	log.SetOutput(&logBuf)
-	defer log.SetOutput(origOut)
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
 	repo := &mockWizardRepo{
 		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
@@ -297,7 +295,11 @@ func TestWizardHandler_Submit_RepoFailLogsOrphan(t *testing.T) {
 		},
 	}
 
-	h := newTestWizardHandler(t, repo, store)
+	var schema types.WizardSchema
+	if err := yaml.Unmarshal([]byte(wizardTestSchema), &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+	h := NewWizardHandler(repo, &schema, store, testMaxUploadBytes, logger)
 	body, ct := buildWizardForm(t,
 		map[string]string{"name": "X", "scope": "Y"},
 		"flow-map.zip", []byte("zip body"),

--- a/open-bbcd/migrations/007_unique_parent_version_id.sql
+++ b/open-bbcd/migrations/007_unique_parent_version_id.sql
@@ -1,0 +1,10 @@
+-- migrations/007_unique_parent_version_id.sql
+-- Enforce linear version chains: each agent can be the parent of at most one child.
+
+-- +goose Up
+ALTER TABLE agents
+  ADD CONSTRAINT agents_parent_version_id_unique UNIQUE (parent_version_id);
+
+-- +goose Down
+ALTER TABLE agents
+  DROP CONSTRAINT IF EXISTS agents_parent_version_id_unique;


### PR DESCRIPTION
## Summary

Salvages the two genuinely useful, non-superseded pieces from the abandoned `feat/agent-versioning` branch (PR #13, which is being closed).

- **slog JSON logger** replaces stdlib `log` package. Set as default in `main.go`, threaded through `NewAPI` → `WizardHandler` and `UIHandler`.
- **HTTP request middleware** (`handler.RequestLogger`) wraps the mux and logs every request with `method`, `path`, `status`, `duration_ms`, `remote_addr`. Level is derived from status: 5xx → Error, 4xx → Warn, else Info.
- **Migration 007** adds a `UNIQUE` constraint on `agents.parent_version_id`. Each agent can be the parent of at most one child — keeps version chains linear at the DB level, matching the assumption that `AgentRepository.ListGrouped` walks up by following a single parent edge.

## What was dropped from PR #13

The other pieces from `feat/agent-versioning` were left behind:

- `GET/POST /agents/{id}/versions` REST API — no consumer.
- `GET/POST /agents/edit` BO edit UI + `agent-edit.html` / `agent-version-detail.html` templates — superseded by the new flow-map configurator on `main` (`/agents/{id}/configure/*`), which now owns the agent-editing workflow.

## Test plan

- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `gofmt -l .` (no diffs)
- [ ] Apply migration 007 on a fresh DB, verify constraint by trying to insert two children for the same parent (should fail with unique violation)
- [ ] Boot the server, hit any endpoint, confirm JSON-formatted request logs on stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)