### PR TITLE
feat(aikdm): v2 bundle schema — capabilities[] section + tag rename

### DIFF
--- a/aikdm/README.md
+++ b/aikdm/README.md
@@ -22,7 +22,7 @@ ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
     --output /path/to/bundle.yaml
 ```
 
-Output is YAML with `metadata`, `main_prompt`, `skills[]`, and `external_actions[]`. Omit `--output` to stream to stdout. Progress events go to stderr as NDJSON.
+Output is YAML with `metadata`, `main_prompt`, `capabilities[]`, `skills[]`, and `external_actions[]`. Omit `--output` to stream to stdout. Progress events go to stderr as NDJSON.
 
 ## Environment variables
 

--- a/aikdm/aikdm/agents.py
+++ b/aikdm/aikdm/agents.py
@@ -68,7 +68,7 @@ layout. You produce the prompt body for THIS ONE skill.
 
 Rules:
 - Fill every LLM-synthesized tag in the scaffold with your own prose.
-- The <resources> block names a single mcp_server with name=proposed_tool
+- The <capabilities> block names a single mcp_server with name=proposed_tool
   from the input. Never include HTTP method, path, or parameters.
 - The <examples> block shows 2-3 execution-level examples for this skill
   (a representative turn inside the skill, not skill routing).
@@ -112,7 +112,7 @@ Your job: identify substantive issues IN THIS SKILL PROMPT that would
 mislead an agent.
 
 Focus on:
-- The <resources> block: mcp_server name must equal target_skill.proposed_tool.
+- The <capabilities> block: mcp_server name must equal target_skill.proposed_tool.
   No HTTP method/path/parameters allowed.
 - <examples> being routing examples rather than execution examples.
 - Skill body contradicting the input scope or should_not_do.

--- a/aikdm/aikdm/orchestrator.py
+++ b/aikdm/aikdm/orchestrator.py
@@ -27,6 +27,7 @@ from aikdm.config import Settings
 from aikdm.progress import ProgressEmitter
 from aikdm.schemas import (
     Bundle,
+    BundleCapability,
     BundleMetadata,
     ExternalAction,
     FlowMapConfig,
@@ -288,6 +289,15 @@ def _assemble_bundle(
         [main_outcome.rounds_run] + [o.rounds_run for o in skill_outcomes.values()]
     )
 
+    capabilities = [
+        BundleCapability(
+            name=c.name,
+            description=c.summary or "",
+            proposed_tool=c.name,
+        )
+        for c in config.capabilities
+    ]
+
     metadata = BundleMetadata(
         config_schema_version=config.schema_version,
         prompt_schema_version=prompt_schema.version,
@@ -306,6 +316,7 @@ def _assemble_bundle(
     return Bundle(
         metadata=metadata,
         main_prompt=main_outcome.body,
+        capabilities=capabilities,
         skills=skills,
         external_actions=external_actions,
     )

--- a/aikdm/aikdm/orchestrator.py
+++ b/aikdm/aikdm/orchestrator.py
@@ -289,6 +289,10 @@ def _assemble_bundle(
         [main_outcome.rounds_run] + [o.rounds_run for o in skill_outcomes.values()]
     )
 
+    # proposed_tool falls back to c.name because the input Capability has no
+    # proposed_tool field today. tools[] (HTTP endpoint metadata) is intentionally
+    # omitted from the bundle — the future real-MCP wiring ticket reads it from
+    # the input config, not the bundle. See run-agent-design.md §8.2.
     capabilities = [
         BundleCapability(
             name=c.name,

--- a/aikdm/aikdm/schemas.py
+++ b/aikdm/aikdm/schemas.py
@@ -140,11 +140,22 @@ class ExternalAction(BaseModel):
     external_note: str
 
 
+class BundleCapability(BaseModel):
+    """Capability passed through from FlowMapConfig.capabilities at bundle generation time."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    description: str
+    proposed_tool: str
+
+
 class Bundle(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     metadata: BundleMetadata
     main_prompt: str
+    capabilities: list[BundleCapability] = Field(default_factory=list)
     skills: list[SkillPrompt] = Field(default_factory=list)
     external_actions: list[ExternalAction] = Field(default_factory=list)
 

--- a/aikdm/aikdm/templates/skill_prompt.xml.j2
+++ b/aikdm/aikdm/templates/skill_prompt.xml.j2
@@ -1,10 +1,10 @@
 <role><!-- LLM: what this skill is responsible for --></role>
 <objective><!-- LLM: concrete outcome the skill must achieve --></objective>
-<resources>
+<capabilities>
   <mcp_server name="{{ skill.proposed_tool }}">
     <description><!-- LLM: 1-2 sentence purpose from capability summary, no HTTP detail --></description>
     <usage><!-- LLM: when to call this server --></usage>
   </mcp_server>
-</resources>
+</capabilities>
 <guardrails><!-- LLM: skill-specific guardrails consistent with main prompt --></guardrails>
 <examples><!-- LLM: 2-3 short example exchanges --></examples>

--- a/aikdm/schemas/prompt-v1.yaml
+++ b/aikdm/schemas/prompt-v1.yaml
@@ -1,4 +1,4 @@
-version: v1
+version: v2
 
 main_prompt:
   - name: role
@@ -56,6 +56,11 @@ main_prompt:
     source: config_derived
     required: false
     guidance: "Bulleted list of external skills the agent must redirect the user to."
+  - name: capabilities
+    tag: capabilities
+    source: config_derived
+    required: true
+    guidance: "Structured list copied through from flow_map_config.capabilities. Each entry: name, description, proposed_tool. No LLM synthesis."
 
 skill_prompt:
   - name: role
@@ -68,8 +73,8 @@ skill_prompt:
     source: llm_synthesized
     required: true
     guidance: "Concrete outcome the skill must achieve."
-  - name: resources
-    tag: resources
+  - name: capabilities
+    tag: capabilities
     source: llm_synthesized
     required: true
     guidance: "Describe the linked capability as an MCP server. Name = proposed_tool. 1-2 sentence purpose statement. No HTTP detail."

--- a/aikdm/tests/fixtures/expected_bundles/coffee_shop.yaml
+++ b/aikdm/tests/fixtures/expected_bundles/coffee_shop.yaml
@@ -1,6 +1,6 @@
 metadata:
   config_schema_version: 1
-  prompt_schema_version: v1
+  prompt_schema_version: v2
   model_generator: claude-haiku-4-5
   model_critic: claude-haiku-4-5
   critic_rounds_run: 1
@@ -11,6 +11,7 @@ metadata:
     critic_in: 3
     critic_out: 3
 main_prompt: <role>r</role>
+capabilities: []
 skills:
   - name: place_order
     description: Guide the user through choosing items and placing an order.

--- a/aikdm/tests/fixtures/expected_bundles/coffee_shop.yaml
+++ b/aikdm/tests/fixtures/expected_bundles/coffee_shop.yaml
@@ -11,7 +11,13 @@ metadata:
     critic_in: 3
     critic_out: 3
 main_prompt: <role>r</role>
-capabilities: []
+capabilities:
+  - name: order_create
+    description: Create a new coffee order.
+    proposed_tool: order_create
+  - name: rewards_lookup
+    description: Look up rewards balance for a customer.
+    proposed_tool: rewards_lookup
 skills:
   - name: place_order
     description: Guide the user through choosing items and placing an order.

--- a/aikdm/tests/integration/test_cli.py
+++ b/aikdm/tests/integration/test_cli.py
@@ -80,7 +80,7 @@ def test_generate_agent_writes_bundle_to_stdout(stub_llm):
     assert result.exit_code == 0, result.stderr
     bundle = yaml.safe_load(result.stdout)
     assert bundle["main_prompt"] == "<role>r</role>"
-    assert bundle["metadata"]["prompt_schema_version"] == "v1"
+    assert bundle["metadata"]["prompt_schema_version"] == "v2"
 
 
 def test_generate_agent_writes_bundle_to_output_path(stub_llm, tmp_path):

--- a/aikdm/tests/smoke/test_real_model.py
+++ b/aikdm/tests/smoke/test_real_model.py
@@ -23,7 +23,7 @@ def test_real_model_generates_valid_bundle():
     assert result.exit_code == 0, result.stderr
 
     bundle = yaml.safe_load(result.stdout)
-    assert bundle["metadata"]["prompt_schema_version"] == "v1"
+    assert bundle["metadata"]["prompt_schema_version"] == "v2"
     assert bundle["main_prompt"].strip().startswith("<")
     assert len(bundle["skills"]) >= 1
     assert all({"name", "description", "prompt"} <= set(s) for s in bundle["skills"])

--- a/aikdm/tests/smoke/test_real_model.py
+++ b/aikdm/tests/smoke/test_real_model.py
@@ -27,4 +27,4 @@ def test_real_model_generates_valid_bundle():
     assert bundle["main_prompt"].strip().startswith("<")
     assert len(bundle["skills"]) >= 1
     assert all({"name", "description", "prompt"} <= set(s) for s in bundle["skills"])
-    assert all("<resources>" in s["prompt"] for s in bundle["skills"])
+    assert all("<capabilities>" in s["prompt"] for s in bundle["skills"])

--- a/aikdm/tests/unit/test_loader.py
+++ b/aikdm/tests/unit/test_loader.py
@@ -43,7 +43,7 @@ def test_load_flow_map_config_schema_violation(tmp_path):
         load_flow_map_config(bad)
 
 
-def test_load_prompt_schema_loads_v1():
+def test_load_prompt_schema_loads_v2():
     schema = load_prompt_schema(PROMPT_SCHEMA)
     assert schema.version == "v2"
 

--- a/aikdm/tests/unit/test_loader.py
+++ b/aikdm/tests/unit/test_loader.py
@@ -45,7 +45,7 @@ def test_load_flow_map_config_schema_violation(tmp_path):
 
 def test_load_prompt_schema_loads_v1():
     schema = load_prompt_schema(PROMPT_SCHEMA)
-    assert schema.version == "v1"
+    assert schema.version == "v2"
 
 
 def test_write_bundle_to_path(tmp_path):

--- a/aikdm/tests/unit/test_orchestrator.py
+++ b/aikdm/tests/unit/test_orchestrator.py
@@ -226,3 +226,27 @@ async def test_orchestrator_propagates_skill_generation_failure(mocker, settings
             settings,
             ProgressEmitter(io.StringIO()),
         )
+
+
+async def test_orchestrator_passes_capabilities_through_to_bundle(mocker, settings):
+    """Capabilities from FlowMapConfig are passed through to Bundle as BundleCapability items."""
+    _patch_adk(mocker)
+    _patch_main_clean(mocker)
+    _patch_skill_clean(mocker)
+
+    config = load_flow_map_config(CONFIG_PATH)
+    schema = load_prompt_schema(SCHEMA_PATH)
+    assert len(config.capabilities) > 0, "fixture must have capabilities to test pass-through"
+
+    emitter = ProgressEmitter(io.StringIO())
+    bundle = await orchestrator.run_generation(
+        config=config, prompt_schema=schema, settings=settings, progress=emitter,
+    )
+
+    assert len(bundle.capabilities) == len(config.capabilities)
+    for i, c in enumerate(config.capabilities):
+        assert bundle.capabilities[i].name == c.name
+        # FlowMapConfig.Capability uses `summary`; bundle uses `description`.
+        assert bundle.capabilities[i].description == (c.summary or "")
+        # Capability doesn't have proposed_tool; fall back to name.
+        assert bundle.capabilities[i].proposed_tool == c.name

--- a/aikdm/tests/unit/test_schemas.py
+++ b/aikdm/tests/unit/test_schemas.py
@@ -54,13 +54,14 @@ def test_prompt_schema_loads_from_yaml():
     data = yaml.safe_load(PROMPT_SCHEMA_PATH.read_text())
     schema = PromptSchema.model_validate(data)
 
-    assert schema.version == "v1"
+    assert schema.version == "v2"
     main_section_names = [s.name for s in schema.main_prompt]
     assert "role" in main_section_names
     assert "guardrails" in main_section_names
     assert "external_actions" in main_section_names
+    assert "capabilities" in main_section_names
     skill_section_names = [s.name for s in schema.skill_prompt]
-    assert "resources" in skill_section_names
+    assert "capabilities" in skill_section_names
 
 
 def test_prompt_section_classifies_source():

--- a/aikdm/tests/unit/test_templates.py
+++ b/aikdm/tests/unit/test_templates.py
@@ -61,4 +61,4 @@ def test_skill_scaffold_renders_proposed_tool_as_mcp_server_name():
     xml = render_skill_prompt_scaffold(skill, capability)
     assert 'name="place_order"' in xml  # MCP server name == proposed_tool
     assert "<role>" in xml
-    assert "<resources>" in xml
+    assert "<capabilities>" in xml


### PR DESCRIPTION
## Summary

Prereq commit for the open-bbcd run-agent feature ([issue #5](https://github.com/DACdigital/OpenBBC/issues/5)). Bumps `aikdm`'s bundle schema from `v1` to `v2`:

- **New top-level `capabilities[]` section in the bundle** (`source: config_derived`) — copied through from `FlowMapConfig.capabilities` without LLM synthesis. Each entry: `{name, description, proposed_tool}`. This gives the future open-bbcd runtime a machine-readable capability list to wire mock tools against (and real MCP tools later).
- **`<resources>` → `<capabilities>` XML tag rename** inside per-skill prompts (template + critic prompt + tests). Unifies terminology repo-wide (`bbc-discovery/flow-map-compiler` and `flow_map_config` already use "capability"; `<resources>` was the last hold-out).
- **Bundle metadata's `prompt_schema_version` advances to `"v2"` automatically** because `orchestrator.py` already pulled the value from the loaded `prompt_schema.version` field — no code change needed for the version bump itself.

Backward compatible at parse time: `Bundle.capabilities` defaults to `[]` so v1-shaped YAMLs still validate.

## What's in this PR

| Commit | What |
|---|---|
| `792d918` | Schema YAML: bump `version:` + add capabilities main_prompt entry + rename `<resources>` |
| `952965d` | Pydantic: new `BundleCapability` model + field on `Bundle` |
| `df43259` | Test fixtures + assertions: downstream cleanup of the schema bump |
| `d4f004f` | Orchestrator: pass `config.capabilities` through to `bundle.capabilities` (TDD) |
| `dc0c185` | Jinja template: `<resources>` → `<capabilities>` |
| `033f340` | Critic prompt: `<resources>` → `<capabilities>` |
| `77866b9` | Address final code review (missed smoke-test assertion, README sentence, test name, inline comment) |

## Test plan

- [x] `make test` — 57 tests pass (48 unit + 8 integration + 1 new orchestrator passthrough test)
- [x] `uv run ruff check .` — clean
- [x] Repo-wide `grep '<resources>'` → zero matches across `aikdm/`
- [ ] Smoke test against real LLM (gated, run locally): `RUN_SMOKE=1 ANTHROPIC_API_KEY=… make test-smoke`

## Follow-ups (not in this PR)

- open-bbcd run-agent feature consumes the new `bundle.capabilities[]` — see `docs/superpowers/specs/2026-06-04-run-agent-design.md`.
- Tools metadata (HTTP endpoint detail in `Capability.tools[]`) intentionally NOT carried into the bundle — the real-MCP-wiring ticket reads it from the input config, per spec §8.2. Commented inline in `orchestrator.py:292`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)