### PR TITLE
refactor(open-bbcd): split agents into agents + agent_versions

### DIFF
--- a/open-bbcd/internal/chat/deployed_store.go
+++ b/open-bbcd/internal/chat/deployed_store.go
@@ -27,18 +27,16 @@ func NewDeployedChatStore(repo DeployedRepositoryAPI) *DeployedChatStore {
 	return &DeployedChatStore{repo: repo}
 }
 
-// EnsureSession verifies the session row exists AND belongs to the given
-// chain root. Unlike BO chat's lazy creation, deployed sessions must be
-// created explicitly before /turn (so user_id scope can be enforced).
-func (s *DeployedChatStore) EnsureSession(ctx context.Context, sessionID, agentID string) error {
-	sess, err := s.repo.GetSessionByID(ctx, sessionID)
-	if err != nil {
-		return err
-	}
-	if sess.AgentID != agentID {
-		return types.ErrNotFound
-	}
-	return nil
+// EnsureSession in the deployed runtime only verifies the session row exists.
+// The deployed handler validates (session_id, user_id) and the session's
+// agent_id BEFORE invoking the orchestrator, so the scope check is already
+// done by the time this runs. The orchestrator's "agentID" parameter in the
+// deployed runtime is actually a version row's id (the resolved currently-
+// deployed version), which is why a literal sess.AgentID comparison would
+// fail.
+func (s *DeployedChatStore) EnsureSession(ctx context.Context, sessionID, _ string) error {
+	_, err := s.repo.GetSessionByID(ctx, sessionID)
+	return err
 }
 
 // LoadMessages translates DeployedMessage rows to ChatMessage shape for the

--- a/open-bbcd/internal/chat/deployed_store_test.go
+++ b/open-bbcd/internal/chat/deployed_store_test.go
@@ -48,23 +48,23 @@ func (f *fakeDeployedRepo) NextSeq(ctx context.Context, sessionID string) (int, 
 	return len(f.messages[sessionID]) + 1, nil
 }
 
-func TestDeployedChatStore_EnsureSession_MatchesChainRoot(t *testing.T) {
+func TestDeployedChatStore_EnsureSession_ExistingSession(t *testing.T) {
 	f := newFakeDeployedRepo()
 	f.sessions["s1"] = &types.DeployedSession{ID: "s1", AgentID: "chain-A", UserID: "u"}
 	store := NewDeployedChatStore(f)
 
-	if err := store.EnsureSession(context.Background(), "s1", "chain-A"); err != nil {
+	// Scope check is done upstream in the deployed handler — EnsureSession
+	// here only confirms the row exists, regardless of the second arg.
+	if err := store.EnsureSession(context.Background(), "s1", "ignored"); err != nil {
 		t.Fatalf("EnsureSession: %v", err)
 	}
 }
 
-func TestDeployedChatStore_EnsureSession_ChainMismatch_NotFound(t *testing.T) {
+func TestDeployedChatStore_EnsureSession_MissingSession_NotFound(t *testing.T) {
 	f := newFakeDeployedRepo()
-	f.sessions["s1"] = &types.DeployedSession{ID: "s1", AgentID: "chain-A", UserID: "u"}
 	store := NewDeployedChatStore(f)
-
-	err := store.EnsureSession(context.Background(), "s1", "chain-B")
-	if err == nil || !errors.Is(err, types.ErrNotFound) {
+	err := store.EnsureSession(context.Background(), "no-such-session", "ignored")
+	if !errors.Is(err, types.ErrNotFound) {
 		t.Fatalf("want ErrNotFound, got %v", err)
 	}
 }

--- a/open-bbcd/internal/chat/fakes_test.go
+++ b/open-bbcd/internal/chat/fakes_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 type fakeAgentRepo struct {
-	agent *types.Agent
-	err   error
+	version *types.AgentVersion
+	err     error
 }
 
-func (f *fakeAgentRepo) GetByID(ctx context.Context, id string) (*types.Agent, error) {
-	return f.agent, f.err
+func (f *fakeAgentRepo) GetByID(ctx context.Context, id string) (*types.AgentVersion, error) {
+	return f.version, f.err
 }
 
 type fakeChatRepo struct {
@@ -27,16 +27,16 @@ type fakeChatRepo struct {
 	nextSeq  int
 }
 
-func (f *fakeChatRepo) EnsureSession(ctx context.Context, sessionID, agentID string) error {
+func (f *fakeChatRepo) EnsureSession(ctx context.Context, sessionID, scopeID string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.ensured == nil {
 		f.ensured = map[string]string{}
 	}
-	if cur, ok := f.ensured[sessionID]; ok && cur != agentID {
+	if cur, ok := f.ensured[sessionID]; ok && cur != scopeID {
 		return types.ErrSessionAgentMismatch
 	}
-	f.ensured[sessionID] = agentID
+	f.ensured[sessionID] = scopeID
 	return nil
 }
 

--- a/open-bbcd/internal/chat/orchestrator.go
+++ b/open-bbcd/internal/chat/orchestrator.go
@@ -18,13 +18,22 @@ import (
 )
 
 // AgentReader is the narrow agent-side interface the orchestrator needs.
+// The orchestrator is version-centric: it loads a version row (which carries
+// the bundle) by its id. In BO chat the id is a chat_sessions.agent_version_id;
+// in deployed runtime it's resolved via DeployedRepository before Turn.
 type AgentReader interface {
-	GetByID(ctx context.Context, id string) (*types.Agent, error)
+	GetByID(ctx context.Context, versionID string) (*types.AgentVersion, error)
 }
 
 // ChatStore is the narrow chat-repo interface the orchestrator needs.
+//
+// scopeID is the per-impl ownership scope passed through from Turn's agentID
+// parameter: BO chat's ChatRepository treats it as the version row id
+// (chat_sessions.agent_version_id), while DeployedChatStore treats it as the
+// per-agent id (deployed_sessions.agent_id). The orchestrator itself doesn't
+// interpret the value — it just forwards it.
 type ChatStore interface {
-	EnsureSession(ctx context.Context, sessionID, agentID string) error
+	EnsureSession(ctx context.Context, sessionID, scopeID string) error
 	LoadMessages(ctx context.Context, sessionID string) ([]*types.ChatMessage, error)
 	AppendMessages(ctx context.Context, agentVersionID string, msgs []types.ChatMessage) error
 	NextSeq(ctx context.Context, sessionID string) (int, error)
@@ -88,16 +97,20 @@ func (o *Orchestrator) Turn(
 		return err
 	}
 
-	// 1. Load agent + verify bundle exists.
-	agent, err := o.agents.GetByID(ctx, agentID)
+	// 1. Load version + verify bundle exists. `agentID` is the orchestrator's
+	// scope identifier — in BO chat it's the version row id, in deployed
+	// runtime it's been resolved to a version id before Turn is invoked.
+	version, err := o.agents.GetByID(ctx, agentID)
 	if err != nil {
 		return failTurn("agent_load", "load_agent", err)
 	}
-	if len(agent.Bundle) == 0 {
+	if len(version.Bundle) == 0 {
 		return failTurn("agent_not_runnable", "verify_bundle", types.ErrAgentNotRunnable)
 	}
 
-	// 2. Ensure session row exists (lazy-create).
+	// 2. Ensure session row exists (lazy-create). The ChatStore impl decides
+	// how to interpret the second arg (version-id for BO chat,
+	// per-agent-id for deployed runtime).
 	if err := o.chats.EnsureSession(ctx, sessionID, agentID); err != nil {
 		return failTurn("session_error", "ensure_session", err)
 	}
@@ -112,11 +125,11 @@ func (o *Orchestrator) Turn(
 	var bundleHead struct {
 		MainPrompt string `json:"main_prompt"`
 	}
-	if err := json.Unmarshal(agent.Bundle, &bundleHead); err != nil {
+	if err := json.Unmarshal(version.Bundle, &bundleHead); err != nil {
 		return failTurn("bundle_parse", "parse_bundle", err)
 	}
 
-	toolDefs, err := o.tools.Tools(agent.Bundle)
+	toolDefs, err := o.tools.Tools(version.Bundle)
 	if err != nil {
 		return failTurn("tools_init", "build_tool_defs", err)
 	}
@@ -135,7 +148,7 @@ func (o *Orchestrator) Turn(
 	if err != nil {
 		return failTurn("seq_assign", "next_seq_user", err)
 	}
-	if err := o.chats.AppendMessages(ctx, agent.ID, []types.ChatMessage{{
+	if err := o.chats.AppendMessages(ctx, version.ID, []types.ChatMessage{{
 		ID:        userMsgID,
 		SessionID: sessionID,
 		Role:      types.ChatRoleUser,
@@ -241,7 +254,7 @@ func (o *Orchestrator) Turn(
 		if err != nil {
 			return failTurn("seq_assign", "next_seq_assistant", err)
 		}
-		if err := o.chats.AppendMessages(ctx, agent.ID, []types.ChatMessage{{
+		if err := o.chats.AppendMessages(ctx, version.ID, []types.ChatMessage{{
 			ID:        assistantMsgID,
 			SessionID: sessionID,
 			Role:      types.ChatRoleAssistant,
@@ -265,7 +278,7 @@ func (o *Orchestrator) Turn(
 		// Execute the pending tools and build a tool-role message.
 		toolBlocks := make([]llm.Block, 0, len(pendingToolUses))
 		for _, tu := range pendingToolUses {
-			res, err := o.tools.Call(ctx, agent.Bundle, tools.Call{
+			res, err := o.tools.Call(ctx, version.Bundle, tools.Call{
 				ID:    tu.ID,
 				Name:  tu.Name,
 				Input: tu.Input,
@@ -297,7 +310,7 @@ func (o *Orchestrator) Turn(
 		if err != nil {
 			return failTurn("seq_assign", "next_seq_tool", err)
 		}
-		if err := o.chats.AppendMessages(ctx, agent.ID, []types.ChatMessage{{
+		if err := o.chats.AppendMessages(ctx, version.ID, []types.ChatMessage{{
 			ID:        toolMsgID,
 			SessionID: sessionID,
 			Role:      types.ChatRoleTool,

--- a/open-bbcd/internal/chat/orchestrator_test.go
+++ b/open-bbcd/internal/chat/orchestrator_test.go
@@ -15,11 +15,11 @@ import (
 )
 
 func TestOrchestrator_TurnTextOnly(t *testing.T) {
-	agent := &types.Agent{
+	version := &types.AgentVersion{
 		ID:     "agent-1",
 		Bundle: []byte(`{"main_prompt":"sys","skills":[],"capabilities":[]}`),
 	}
-	fakeAgent := &fakeAgentRepo{agent: agent}
+	fakeAgent := &fakeAgentRepo{version: version}
 	fakeChat := &fakeChatRepo{}
 	flm := &fakeLLM{
 		name: "fake",
@@ -66,8 +66,8 @@ func TestOrchestrator_TurnTextOnly(t *testing.T) {
 }
 
 func TestOrchestrator_NoBundle_ReturnsErrAgentNotRunnable(t *testing.T) {
-	agent := &types.Agent{ID: "agent-1", Bundle: nil}
-	fakeAgent := &fakeAgentRepo{agent: agent}
+	version := &types.AgentVersion{ID: "agent-1", Bundle: nil}
+	fakeAgent := &fakeAgentRepo{version: version}
 	o := NewOrchestrator(fakeAgent, &fakeChatRepo{}, &fakeLLM{}, &fakeTools{}, slog.Default())
 
 	var buf bytes.Buffer
@@ -86,7 +86,7 @@ func TestOrchestrator_NoBundle_ReturnsErrAgentNotRunnable(t *testing.T) {
 func TestOrchestrator_AssistantTextPersistsConcatenated(t *testing.T) {
 	// Verifies that streaming deltas accumulate into a single TextBlock
 	// before persistence (we shouldn't end up with one-block-per-delta).
-	agent := &types.Agent{
+	version := &types.AgentVersion{
 		ID:     "a",
 		Bundle: []byte(`{"main_prompt":"sys","skills":[],"capabilities":[]}`),
 	}
@@ -102,7 +102,7 @@ func TestOrchestrator_AssistantTextPersistsConcatenated(t *testing.T) {
 			},
 		},
 	}
-	o := NewOrchestrator(&fakeAgentRepo{agent: agent}, fakeChat, flm, &fakeTools{}, slog.Default())
+	o := NewOrchestrator(&fakeAgentRepo{version: version}, fakeChat, flm, &fakeTools{}, slog.Default())
 
 	var buf bytes.Buffer
 	sink, _ := jsonl.NewFactory().NewWriterSink(&buf)
@@ -133,7 +133,7 @@ func json_unmarshal_test_helper(t *testing.T, raw []byte, dst any) any {
 }
 
 func TestOrchestrator_OneToolRound(t *testing.T) {
-	agent := &types.Agent{
+	version := &types.AgentVersion{
 		ID:     "agent-1",
 		Bundle: []byte(`{"main_prompt":"sys","skills":[],"capabilities":[]}`),
 	}
@@ -158,7 +158,7 @@ func TestOrchestrator_OneToolRound(t *testing.T) {
 	ft := &fakeTools{
 		results: []tools.Result{{ToolUseID: "tu_1", Output: []byte(`{"prompt":"X"}`)}},
 	}
-	o := NewOrchestrator(&fakeAgentRepo{agent: agent}, fakeChat, flm, ft, slog.Default())
+	o := NewOrchestrator(&fakeAgentRepo{version: version}, fakeChat, flm, ft, slog.Default())
 
 	var buf bytes.Buffer
 	sink, _ := jsonl.NewFactory().NewWriterSink(&buf)
@@ -191,7 +191,7 @@ func TestOrchestrator_OneToolRound(t *testing.T) {
 }
 
 func TestOrchestrator_BoundedToolLoop(t *testing.T) {
-	agent := &types.Agent{
+	version := &types.AgentVersion{
 		ID:     "a",
 		Bundle: []byte(`{"main_prompt":"x","skills":[],"capabilities":[]}`),
 	}
@@ -209,7 +209,7 @@ func TestOrchestrator_BoundedToolLoop(t *testing.T) {
 	}
 	flm := &fakeLLM{name: "fake", script: script}
 	ft := &fakeTools{}
-	o := NewOrchestrator(&fakeAgentRepo{agent: agent}, fakeChat, flm, ft, slog.Default())
+	o := NewOrchestrator(&fakeAgentRepo{version: version}, fakeChat, flm, ft, slog.Default())
 	o.MaxToolRounds = 3
 
 	var buf bytes.Buffer

--- a/open-bbcd/internal/handler/agent.go
+++ b/open-bbcd/internal/handler/agent.go
@@ -38,7 +38,7 @@ func (h *AgentHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *AgentHandler) Get(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
+	id := r.PathValue("agent_id")
 	if id == "" {
 		JSON(w, http.StatusBadRequest, ErrorResponse{Error: "id is required"})
 		return

--- a/open-bbcd/internal/handler/api.go
+++ b/open-bbcd/internal/handler/api.go
@@ -30,12 +30,11 @@ const (
 	IdleTimeout  = 60 * time.Second
 )
 
-// configStore satisfies ConfigStore by forwarding methods to the split repos.
-// Embedding both *AgentRepository and *AgentVersionRepository would cause a
-// GetByID ambiguity (one returns *Agent, the other *AgentVersion), so we
-// forward explicitly.
+// configStore satisfies ConfigStore by forwarding methods to AgentVersionRepository.
+// After the flow_map_config move (migration 014), every ConfigStore method is
+// keyed by version_id and lives on AgentVersionRepository — including
+// GetWithAgent, which joins the version's owning agent for display fields.
 type configStore struct {
-	agents   *repository.AgentRepository
 	versions *repository.AgentVersionRepository
 }
 
@@ -43,12 +42,12 @@ func (s *configStore) GetWithAgent(ctx context.Context, versionID string) (*type
 	return s.versions.GetWithAgent(ctx, versionID)
 }
 
-func (s *configStore) GetFlowMapConfig(ctx context.Context, agentID string) ([]byte, string, error) {
-	return s.agents.GetFlowMapConfig(ctx, agentID)
+func (s *configStore) GetFlowMapConfig(ctx context.Context, versionID string) ([]byte, string, error) {
+	return s.versions.GetFlowMapConfig(ctx, versionID)
 }
 
-func (s *configStore) UpdateFlowMapConfig(ctx context.Context, agentID string, cfg []byte) error {
-	return s.agents.UpdateFlowMapConfig(ctx, agentID, cfg)
+func (s *configStore) UpdateFlowMapConfig(ctx context.Context, versionID string, cfg []byte) error {
+	return s.versions.UpdateFlowMapConfig(ctx, versionID, cfg)
 }
 
 func (s *configStore) UpdateStatus(ctx context.Context, versionID, expectedFrom, to string) error {
@@ -83,7 +82,7 @@ func NewAPI(db *sql.DB, store storage.Storage, cfg *config.Config, logger *slog.
 	maxUploadBytes := int64(cfg.Discovery.MaxUploadMB) << 20
 	wizardHandler := NewWizardHandler(agentRepo, &schema, store, maxUploadBytes, logger)
 
-	configuratorHandler, err := NewConfiguratorHandler(&configStore{agents: agentRepo, versions: versionRepo}, &schema, web.Assets)
+	configuratorHandler, err := NewConfiguratorHandler(&configStore{versions: versionRepo}, &schema, web.Assets)
 	if err != nil {
 		fatal("init configurator handler", err)
 	}

--- a/open-bbcd/internal/handler/api.go
+++ b/open-bbcd/internal/handler/api.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/fs"
@@ -29,6 +30,31 @@ const (
 	IdleTimeout  = 60 * time.Second
 )
 
+// configStore satisfies ConfigStore by forwarding methods to the split repos.
+// Embedding both *AgentRepository and *AgentVersionRepository would cause a
+// GetByID ambiguity (one returns *Agent, the other *AgentVersion), so we
+// forward explicitly.
+type configStore struct {
+	agents   *repository.AgentRepository
+	versions *repository.AgentVersionRepository
+}
+
+func (s *configStore) GetWithAgent(ctx context.Context, versionID string) (*types.AgentVersion, *types.Agent, error) {
+	return s.versions.GetWithAgent(ctx, versionID)
+}
+
+func (s *configStore) GetFlowMapConfig(ctx context.Context, agentID string) ([]byte, string, error) {
+	return s.agents.GetFlowMapConfig(ctx, agentID)
+}
+
+func (s *configStore) UpdateFlowMapConfig(ctx context.Context, agentID string, cfg []byte) error {
+	return s.agents.UpdateFlowMapConfig(ctx, agentID, cfg)
+}
+
+func (s *configStore) UpdateStatus(ctx context.Context, versionID, expectedFrom, to string) error {
+	return s.versions.UpdateStatus(ctx, versionID, expectedFrom, to)
+}
+
 func NewAPI(db *sql.DB, store storage.Storage, cfg *config.Config, logger *slog.Logger) http.Handler {
 	fatal := func(msg string, err error) {
 		logger.Error(msg, slog.Any("error", err))
@@ -36,7 +62,9 @@ func NewAPI(db *sql.DB, store storage.Storage, cfg *config.Config, logger *slog.
 	}
 
 	agentRepo := repository.NewAgentRepository(db)
+	versionRepo := repository.NewAgentVersionRepository(db)
 	resourceRepo := repository.NewResourceRepository(db)
+	deployedRepo := repository.NewDeployedRepository(db)
 
 	// Load wizard schema from embedded FS.
 	schemaBytes, err := web.Assets.ReadFile("schemas/wizard-v1.yaml")
@@ -48,14 +76,14 @@ func NewAPI(db *sql.DB, store storage.Storage, cfg *config.Config, logger *slog.
 		fatal("parse wizard schema", err)
 	}
 
-	uiHandler, err := NewUIHandler(agentRepo, &schema, web.Assets, logger)
+	uiHandler, err := NewUIHandler(agentRepo, versionRepo, &schema, web.Assets, logger)
 	if err != nil {
 		fatal("init UI handler", err)
 	}
 	maxUploadBytes := int64(cfg.Discovery.MaxUploadMB) << 20
 	wizardHandler := NewWizardHandler(agentRepo, &schema, store, maxUploadBytes, logger)
 
-	configuratorHandler, err := NewConfiguratorHandler(agentRepo, &schema, web.Assets)
+	configuratorHandler, err := NewConfiguratorHandler(&configStore{agents: agentRepo, versions: versionRepo}, &schema, web.Assets)
 	if err != nil {
 		fatal("init configurator handler", err)
 	}
@@ -77,32 +105,26 @@ func NewAPI(db *sql.DB, store storage.Storage, cfg *config.Config, logger *slog.
 		fatal("unknown chat transport", fmt.Errorf("%q", cfg.Chat.Transport))
 	}
 
-	orchestrator := chat.NewOrchestrator(agentRepo, chatRepo, llmClient, toolHandler, logger)
+	orchestrator := chat.NewOrchestrator(versionRepo, chatRepo, llmClient, toolHandler, logger)
 	orchestrator.Model = cfg.Anthropic.DefaultModel
 	orchestrator.MaxTokens = cfg.Anthropic.MaxTokens
 	orchestrator.MaxToolRounds = cfg.Chat.MaxToolRounds
 
-	chatHandler, err := NewChatHandler(agentRepo, chatRepo, orchestrator, transportFactory, web.Assets, logger)
+	chatHandler, err := NewChatHandler(versionRepo, chatRepo, orchestrator, transportFactory, web.Assets, logger)
 	if err != nil {
 		fatal("init chat handler", err)
 	}
 
-	deployedRepo := repository.NewDeployedRepository(db)
 	deployedChatStore := chat.NewDeployedChatStore(deployedRepo)
-	deployedOrchestrator := chat.NewOrchestrator(agentRepo, deployedChatStore, llmClient, toolHandler, logger)
+	deployedOrchestrator := chat.NewOrchestrator(versionRepo, deployedChatStore, llmClient, toolHandler, logger)
 	deployedOrchestrator.Model = cfg.Anthropic.DefaultModel
 	deployedOrchestrator.MaxTokens = cfg.Anthropic.MaxTokens
 	deployedOrchestrator.MaxToolRounds = cfg.Chat.MaxToolRounds
 
-	deployedHandler := NewDeployedHandler(agentRepo, deployedRepo, deployedChatStore, deployedOrchestrator, transportFactory, logger)
+	deployedHandler := NewDeployedHandler(versionRepo, deployedRepo, deployedChatStore, deployedOrchestrator, transportFactory, logger)
+	deployHandler := NewDeployHandler(agentRepo, versionRepo)
 
 	mux := http.NewServeMux()
-
-	staticFS, err := fs.Sub(web.Assets, "static")
-	if err != nil {
-		fatal("sub static FS", err)
-	}
-	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
 
 	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
@@ -111,54 +133,68 @@ func NewAPI(db *sql.DB, store storage.Storage, cfg *config.Config, logger *slog.
 		}
 		http.Redirect(w, r, "/agents/ui", http.StatusMovedPermanently)
 	})
+
+	// UI listing + wizard
 	mux.HandleFunc("GET /agents/ui", uiHandler.AgentsPage)
 	mux.HandleFunc("GET /agents/new", uiHandler.WizardPage)
 	mux.HandleFunc("GET /agents/new/step/{n}", uiHandler.WizardStep)
 	mux.HandleFunc("POST /agents/wizard", wizardHandler.Submit)
-	mux.HandleFunc("GET /agents/{id}/configure", configuratorHandler.Index)
-	mux.HandleFunc("GET /agents/{id}/configure/flows", configuratorHandler.Flows)
-	mux.HandleFunc("GET /agents/{id}/configure/flows/{flowId}", configuratorHandler.Flows)
-	mux.HandleFunc("GET /agents/{id}/configure/skills", configuratorHandler.Skills)
-	mux.HandleFunc("GET /agents/{id}/configure/skills/{skillId}", configuratorHandler.Skills)
-	mux.HandleFunc("GET /agents/{id}/configure/capabilities", configuratorHandler.Capabilities)
-	mux.HandleFunc("GET /agents/{id}/configure/capabilities/{capName}", configuratorHandler.Capabilities)
-	mux.HandleFunc("GET /agents/{id}/configure/inputs", configuratorHandler.Inputs)
-	mux.HandleFunc("POST /agents/{id}/configure/flows/{flowId}/included", configuratorHandler.FlowIncluded)
-	mux.HandleFunc("GET /agents/{id}/configure/skills/new", configuratorHandler.SkillNew)
-	mux.HandleFunc("POST /agents/{id}/configure/skills", configuratorHandler.SkillCreate)
-	mux.HandleFunc("POST /agents/{id}/configure/skills/{skillId}", configuratorHandler.SkillUpdate)
-	mux.HandleFunc("DELETE /agents/{id}/configure/skills/{skillId}", configuratorHandler.SkillDelete)
-	mux.HandleFunc("POST /agents/{id}/configure/flows/{flowId}/workflow", configuratorHandler.WorkflowUpdate)
-	mux.HandleFunc("GET /agents/{id}/configure/finalize", configuratorHandler.FinalizeConfirm)
-	mux.HandleFunc("POST /agents/{id}/finalize", configuratorHandler.Finalize)
-	mux.HandleFunc("GET /agents/{id}/config.yaml", configuratorHandler.DownloadYAML)
 
-	mux.HandleFunc("GET /agents/{id}/deploy/confirm", uiHandler.DeployConfirm)
-	mux.HandleFunc("GET /agents/{id}/undeploy/confirm", uiHandler.UndeployConfirm)
+	// Per-version configurator
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure", configuratorHandler.Index)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/flows", configuratorHandler.Flows)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/flows/{flowId}", configuratorHandler.Flows)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/skills", configuratorHandler.Skills)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/skills/{skillId}", configuratorHandler.Skills)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/capabilities", configuratorHandler.Capabilities)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/capabilities/{capName}", configuratorHandler.Capabilities)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/inputs", configuratorHandler.Inputs)
+	mux.HandleFunc("POST /agent_versions/{version_id}/configure/flows/{flowId}/included", configuratorHandler.FlowIncluded)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/skills/new", configuratorHandler.SkillNew)
+	mux.HandleFunc("POST /agent_versions/{version_id}/configure/skills", configuratorHandler.SkillCreate)
+	mux.HandleFunc("POST /agent_versions/{version_id}/configure/skills/{skillId}", configuratorHandler.SkillUpdate)
+	mux.HandleFunc("DELETE /agent_versions/{version_id}/configure/skills/{skillId}", configuratorHandler.SkillDelete)
+	mux.HandleFunc("POST /agent_versions/{version_id}/configure/flows/{flowId}/workflow", configuratorHandler.WorkflowUpdate)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/finalize", configuratorHandler.FinalizeConfirm)
+	mux.HandleFunc("POST /agent_versions/{version_id}/finalize", configuratorHandler.Finalize)
+	mux.HandleFunc("GET /agent_versions/{version_id}/config.yaml", configuratorHandler.DownloadYAML)
 
+	// Per-version BO chat
+	mux.HandleFunc("POST /agent_versions/{version_id}/chat/sessions", chatHandler.NewSession)
+	mux.HandleFunc("GET /agent_versions/{version_id}/chat", chatHandler.SessionList)
+	mux.HandleFunc("GET /agent_versions/{version_id}/chat/{session_id}", chatHandler.ChatView)
+	mux.HandleFunc("PATCH /agent_versions/{version_id}/chat/{session_id}/title", chatHandler.UpdateSessionTitle)
+	mux.HandleFunc("POST /agent_versions/{version_id}/chat/{session_id}/turn", chatHandler.Turn)
+
+	// Per-agent deploy/undeploy + confirm modals
+	mux.HandleFunc("POST /agents/{agent_id}/deploy", deployHandler.Deploy)
+	mux.HandleFunc("POST /agents/{agent_id}/undeploy", deployHandler.Undeploy)
+	mux.HandleFunc("GET /agents/{agent_id}/deploy/confirm", uiHandler.DeployConfirm)
+	mux.HandleFunc("GET /agents/{agent_id}/undeploy/confirm", uiHandler.UndeployConfirm)
+
+	// JSON API (per-agent)
 	mux.HandleFunc("GET /health", Health)
 	mux.HandleFunc("POST /agents", agentHandler.Create)
 	mux.HandleFunc("GET /agents", agentHandler.List)
-	mux.HandleFunc("GET /agents/{id}", agentHandler.Get)
-	deployHandler := NewDeployHandler(agentRepo)
-	mux.HandleFunc("POST /agents/{id}/deploy", deployHandler.Deploy)
-	mux.HandleFunc("POST /agents/{id}/undeploy", deployHandler.Undeploy)
+	mux.HandleFunc("GET /agents/{agent_id}", agentHandler.Get)
 	mux.HandleFunc("POST /resources", resourceHandler.Create)
 	mux.HandleFunc("GET /resources/{id}", resourceHandler.Get)
 	mux.HandleFunc("GET /agents/{agent_id}/resources", resourceHandler.ListByAgent)
 
-	mux.HandleFunc("POST /agents/{id}/chat/sessions",           chatHandler.NewSession)
-	mux.HandleFunc("GET /agents/{id}/chat",                     chatHandler.SessionList)
-	mux.HandleFunc("GET /agents/{id}/chat/{session_id}",        chatHandler.ChatView)
-	mux.HandleFunc("PATCH /agents/{id}/chat/{session_id}/title", chatHandler.UpdateSessionTitle)
-	mux.HandleFunc("POST /agents/{id}/chat/{session_id}/turn",  chatHandler.Turn)
-
+	// Deployed runtime (unchanged URLs)
 	mux.HandleFunc("POST /deployed/{agent_id}/sessions", deployedHandler.CreateSession)
 	mux.HandleFunc("GET /deployed/{agent_id}/sessions", deployedHandler.ListSessions)
 	mux.HandleFunc("GET /deployed/{agent_id}/sessions/{session_id}", deployedHandler.GetSession)
 	mux.HandleFunc("PATCH /deployed/{agent_id}/sessions/{session_id}/title", deployedHandler.UpdateTitle)
 	mux.HandleFunc("DELETE /deployed/{agent_id}/sessions/{session_id}", deployedHandler.DeleteSession)
 	mux.HandleFunc("POST /deployed/{agent_id}/sessions/{session_id}/turn", deployedHandler.Turn)
+
+	// Static
+	staticFS, err := fs.Sub(web.Assets, "static")
+	if err != nil {
+		fatal("sub static FS", err)
+	}
+	mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.FS(staticFS))))
 
 	return RequestLogger(logger, mux)
 }

--- a/open-bbcd/internal/handler/chat.go
+++ b/open-bbcd/internal/handler/chat.go
@@ -19,21 +19,22 @@ import (
 	"github.com/google/uuid"
 )
 
-// ChatAgentReader is the narrow agent interface needed by ChatHandler.
-// AgentID is used to build the back-link URL on the sessions page so
-// it points at the chain (by root ID), not at a specific version.
+// ChatAgentReader is the narrow agent-version interface needed by ChatHandler.
+// One call returns the version row and its owning Agent via JOIN so the
+// handler can populate both VersionID (URL param) and AgentID (back-link)
+// page-data fields without a second round-trip.
 type ChatAgentReader interface {
-	GetByID(ctx context.Context, id string) (*types.Agent, error)
-	AgentIDOf(ctx context.Context, versionID string) (string, error)
+	GetWithAgent(ctx context.Context, versionID string) (*types.AgentVersion, *types.Agent, error)
 }
 
 // ChatSessionStore is the narrow chat-repo interface needed by ChatHandler.
+// All non-message methods are scoped to an agent version (chat_sessions.agent_version_id).
 type ChatSessionStore interface {
-	EnsureSession(ctx context.Context, sessionID, agentID string) error
-	GetSession(ctx context.Context, sessionID, agentID string) (*types.ChatSession, error)
-	ListSessions(ctx context.Context, agentID string) ([]*types.ChatSession, error)
+	EnsureSession(ctx context.Context, sessionID, versionID string) error
+	GetSession(ctx context.Context, sessionID, versionID string) (*types.ChatSession, error)
+	ListSessions(ctx context.Context, versionID string) ([]*types.ChatSession, error)
 	LoadMessages(ctx context.Context, sessionID string) ([]*types.ChatMessage, error)
-	UpdateSessionTitle(ctx context.Context, sessionID, agentID, title string) error
+	UpdateSessionTitle(ctx context.Context, sessionID, versionID, title string) error
 }
 
 // TurnRunner is the orchestrator dependency. Implemented by *chat.Orchestrator.
@@ -91,38 +92,38 @@ func NewChatHandler(
 }
 
 // NewSession creates a new chat_sessions row and 303-redirects to the chat view.
-// Returns 409 if the agent has no bundle yet.
+// Returns 409 if the version has no bundle yet.
 func (h *ChatHandler) NewSession(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	agent, err := h.agents.GetByID(r.Context(), agentID)
+	versionID := r.PathValue("version_id")
+	version, _, err := h.agents.GetWithAgent(r.Context(), versionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
-	if len(agent.Bundle) == 0 {
+	if len(version.Bundle) == 0 {
 		Error(w, types.ErrAgentNotRunnable)
 		return
 	}
 	sessionID := uuid.NewString()
-	if err := h.chats.EnsureSession(r.Context(), sessionID, agentID); err != nil {
+	if err := h.chats.EnsureSession(r.Context(), sessionID, versionID); err != nil {
 		Error(w, err)
 		return
 	}
-	http.Redirect(w, r, "/agents/"+agentID+"/chat/"+sessionID, http.StatusSeeOther)
+	http.Redirect(w, r, "/agent_versions/"+versionID+"/chat/"+sessionID, http.StatusSeeOther)
 }
 
 type sessionListPageData struct {
-	Active      string
-	AgentID     string // version row's ID (URL path param semantics, legacy)
-	AgentRootID string // stable agent ID, used for back-link to agent listing
-	AgentName   string
-	Sessions    []*types.ChatSession
+	Active    string
+	VersionID string // URL path param value (a version row's ID)
+	AgentID   string // stable agent ID, used for back-link to agent listing
+	AgentName string
+	Sessions  []*types.ChatSession
 }
 
 // SessionList renders the session-list page for one agent version.
 func (h *ChatHandler) SessionList(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	agent, err := h.agents.GetByID(r.Context(), agentID)
+	versionID := r.PathValue("version_id")
+	_, agent, err := h.agents.GetWithAgent(r.Context(), versionID)
 	if err != nil {
 		if errors.Is(err, types.ErrNotFound) {
 			http.NotFound(w, r)
@@ -131,29 +132,25 @@ func (h *ChatHandler) SessionList(w http.ResponseWriter, r *http.Request) {
 		Error(w, err)
 		return
 	}
-	rootID, err := h.agents.AgentIDOf(r.Context(), agentID)
-	if err != nil {
-		Error(w, err)
-		return
-	}
-	sessions, err := h.chats.ListSessions(r.Context(), agentID)
+	sessions, err := h.chats.ListSessions(r.Context(), versionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
 	data := sessionListPageData{
-		Active:      "agents",
-		AgentID:     agentID,
-		AgentRootID: rootID,
-		AgentName:   agent.Name,
-		Sessions:    sessions,
+		Active:    "agents",
+		VersionID: versionID,
+		AgentID:   agent.ID,
+		AgentName: agent.Name,
+		Sessions:  sessions,
 	}
 	renderTemplate(w, h.sessionsTmpl, "layout", data)
 }
 
 type chatViewPageData struct {
 	Active       string
-	AgentID      string
+	VersionID    string // URL path param value (a version row's ID)
+	AgentID      string // stable agent ID, used for back-link to agent listing
 	AgentName    string
 	SessionID    string
 	SessionTitle string
@@ -274,10 +271,10 @@ func prettyJSON(raw json.RawMessage) string {
 // ChatView renders the chat UI for one session. If session_id doesn't
 // exist yet, renders an empty view (lazy creation by first POST /turn).
 func (h *ChatHandler) ChatView(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
+	versionID := r.PathValue("version_id")
 	sessionID := r.PathValue("session_id")
 
-	agent, err := h.agents.GetByID(r.Context(), agentID)
+	version, agent, err := h.agents.GetWithAgent(r.Context(), versionID)
 	if err != nil {
 		if errors.Is(err, types.ErrNotFound) {
 			http.NotFound(w, r)
@@ -297,7 +294,7 @@ func (h *ChatHandler) ChatView(w http.ResponseWriter, r *http.Request) {
 	// Session row may not exist yet (lazy-created on first turn). A missing
 	// row is fine — leave title empty. Other errors propagate.
 	var sessionTitle string
-	if sess, err := h.chats.GetSession(r.Context(), sessionID, agentID); err == nil {
+	if sess, err := h.chats.GetSession(r.Context(), sessionID, versionID); err == nil {
 		sessionTitle = sess.Title
 	} else if !errors.Is(err, types.ErrNotFound) {
 		Error(w, err)
@@ -306,12 +303,13 @@ func (h *ChatHandler) ChatView(w http.ResponseWriter, r *http.Request) {
 
 	data := chatViewPageData{
 		Active:       "agents",
-		AgentID:      agentID,
+		VersionID:    versionID,
+		AgentID:      agent.ID,
 		AgentName:    agent.Name,
 		SessionID:    sessionID,
 		SessionTitle: sessionTitle,
 		Messages:     buildMessageViews(msgs),
-		HasBundle:    len(agent.Bundle) > 0,
+		HasBundle:    len(version.Bundle) > 0,
 	}
 	renderTemplate(w, h.viewTmpl, "layout", data)
 }
@@ -319,7 +317,7 @@ func (h *ChatHandler) ChatView(w http.ResponseWriter, r *http.Request) {
 // UpdateSessionTitle accepts a JSON body {"title": "..."} and updates the
 // session title. Empty string clears the title (reverts to "Untitled session").
 func (h *ChatHandler) UpdateSessionTitle(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
+	versionID := r.PathValue("version_id")
 	sessionID := r.PathValue("session_id")
 	var body struct {
 		Title string `json:"title"`
@@ -333,7 +331,7 @@ func (h *ChatHandler) UpdateSessionTitle(w http.ResponseWriter, r *http.Request)
 	if len(title) > maxTitleLen {
 		title = title[:maxTitleLen]
 	}
-	if err := h.chats.UpdateSessionTitle(r.Context(), sessionID, agentID, title); err != nil {
+	if err := h.chats.UpdateSessionTitle(r.Context(), sessionID, versionID, title); err != nil {
 		Error(w, err)
 		return
 	}
@@ -356,13 +354,13 @@ type TurnInputBlock struct {
 // already been streamed by the orchestrator as ErrorEvent — they are
 // only logged here.
 func (h *ChatHandler) Turn(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
+	versionID := r.PathValue("version_id")
 	sessionID := r.PathValue("session_id")
 
 	var req TurnRequest
 	if err := DecodeJSON(r, &req); err != nil {
 		h.logger.Error("chat turn: decode JSON request body failed",
-			slog.String("agent_id", agentID),
+			slog.String("version_id", versionID),
 			slog.String("session_id", sessionID),
 			slog.Any("err", err),
 		)
@@ -389,7 +387,7 @@ func (h *ChatHandler) Turn(w http.ResponseWriter, r *http.Request) {
 	sink, err := h.transport.NewSink(w)
 	if err != nil {
 		h.logger.Error("chat turn: transport sink construction failed",
-			slog.String("agent_id", agentID),
+			slog.String("version_id", versionID),
 			slog.String("session_id", sessionID),
 			slog.Any("err", err),
 		)
@@ -401,9 +399,11 @@ func (h *ChatHandler) Turn(w http.ResponseWriter, r *http.Request) {
 	// streaming. Defer-closing the sink is owned here, NOT by the orchestrator.
 	w.WriteHeader(http.StatusOK)
 
-	if err := h.orch.Turn(r.Context(), agentID, sessionID, input, sink); err != nil {
+	// orch.Turn's first scope-id param is still named `agentID` (orchestrator
+	// legacy — see Task 6 notes). It expects a version row's ID.
+	if err := h.orch.Turn(r.Context(), versionID, sessionID, input, sink); err != nil {
 		h.logger.Error("chat turn failed",
-			slog.String("agent_id", agentID),
+			slog.String("version_id", versionID),
 			slog.String("session_id", sessionID),
 			slog.Any("err", err),
 		)

--- a/open-bbcd/internal/handler/chat_test.go
+++ b/open-bbcd/internal/handler/chat_test.go
@@ -23,17 +23,13 @@ import (
 // (which mock the orchestrator's dependencies).
 
 type stubAgentRepo struct {
-	agent  *types.Agent
-	rootID string
-	err    error
+	version *types.AgentVersion
+	agent   *types.Agent
+	err     error
 }
 
-func (s *stubAgentRepo) GetByID(ctx context.Context, id string) (*types.Agent, error) {
-	return s.agent, s.err
-}
-
-func (s *stubAgentRepo) AgentIDOf(ctx context.Context, versionID string) (string, error) {
-	return s.rootID, s.err
+func (s *stubAgentRepo) GetWithAgent(ctx context.Context, versionID string) (*types.AgentVersion, *types.Agent, error) {
+	return s.version, s.agent, s.err
 }
 
 type stubChatStore struct {
@@ -43,20 +39,20 @@ type stubChatStore struct {
 	err      error
 }
 
-func (s *stubChatStore) EnsureSession(ctx context.Context, sessionID, agentID string) error {
+func (s *stubChatStore) EnsureSession(ctx context.Context, sessionID, versionID string) error {
 	s.ensured = append(s.ensured, sessionID)
 	return s.err
 }
-func (s *stubChatStore) GetSession(ctx context.Context, sessionID, agentID string) (*types.ChatSession, error) {
-	return &types.ChatSession{ID: sessionID, AgentID: agentID}, s.err
+func (s *stubChatStore) GetSession(ctx context.Context, sessionID, versionID string) (*types.ChatSession, error) {
+	return &types.ChatSession{ID: sessionID, AgentVersionID: versionID}, s.err
 }
-func (s *stubChatStore) ListSessions(ctx context.Context, agentID string) ([]*types.ChatSession, error) {
+func (s *stubChatStore) ListSessions(ctx context.Context, versionID string) ([]*types.ChatSession, error) {
 	return s.sessions, s.err
 }
 func (s *stubChatStore) LoadMessages(ctx context.Context, sessionID string) ([]*types.ChatMessage, error) {
 	return s.messages, s.err
 }
-func (s *stubChatStore) UpdateSessionTitle(ctx context.Context, sessionID, agentID, title string) error {
+func (s *stubChatStore) UpdateSessionTitle(ctx context.Context, sessionID, versionID, title string) error {
 	return s.err
 }
 
@@ -88,7 +84,10 @@ func emptyTemplateFS() fs.FS {
 func newTestChatHandler(t *testing.T, runner *stubTurnRunner) *ChatHandler {
 	t.Helper()
 	h, err := NewChatHandler(
-		&stubAgentRepo{agent: &types.Agent{ID: "a", Bundle: []byte(`{}`)}},
+		&stubAgentRepo{
+			version: &types.AgentVersion{ID: "v", AgentID: "a", Bundle: []byte(`{}`)},
+			agent:   &types.Agent{ID: "a", Name: "test"},
+		},
 		&stubChatStore{},
 		runner,
 		jsonl.NewFactory(),
@@ -108,8 +107,8 @@ func TestChatHandler_Turn_HappyPath(t *testing.T) {
 	body, _ := json.Marshal(TurnRequest{
 		Input: []TurnInputBlock{{Type: "text", Text: "hi"}},
 	})
-	r := httptest.NewRequest("POST", "/agents/a/chat/s/turn", bytes.NewReader(body))
-	r.SetPathValue("id", "a")
+	r := httptest.NewRequest("POST", "/agent_versions/v/chat/s/turn", bytes.NewReader(body))
+	r.SetPathValue("version_id", "v")
 	r.SetPathValue("session_id", "s")
 	w := httptest.NewRecorder()
 
@@ -121,7 +120,7 @@ func TestChatHandler_Turn_HappyPath(t *testing.T) {
 	if !strings.Contains(w.Body.String(), "text_delta") {
 		t.Fatalf("expected text_delta in body, got: %q", w.Body.String())
 	}
-	if runner.capturedAgentID != "a" || runner.capturedSessionID != "s" {
+	if runner.capturedAgentID != "v" || runner.capturedSessionID != "s" {
 		t.Fatalf("captured ids: %+v", runner)
 	}
 	if len(runner.capturedInput) != 1 {
@@ -135,8 +134,8 @@ func TestChatHandler_Turn_HappyPath(t *testing.T) {
 func TestChatHandler_Turn_MalformedJSON_Returns400(t *testing.T) {
 	h := newTestChatHandler(t, &stubTurnRunner{})
 
-	r := httptest.NewRequest("POST", "/agents/a/chat/s/turn", strings.NewReader("{not json"))
-	r.SetPathValue("id", "a")
+	r := httptest.NewRequest("POST", "/agent_versions/v/chat/s/turn", strings.NewReader("{not json"))
+	r.SetPathValue("version_id", "v")
 	r.SetPathValue("session_id", "s")
 	w := httptest.NewRecorder()
 
@@ -157,8 +156,8 @@ func TestChatHandler_Turn_SetsSSEHeaders(t *testing.T) {
 	body, _ := json.Marshal(TurnRequest{
 		Input: []TurnInputBlock{{Type: "text", Text: "hi"}},
 	})
-	r := httptest.NewRequest("POST", "/agents/a/chat/s/turn", bytes.NewReader(body))
-	r.SetPathValue("id", "a")
+	r := httptest.NewRequest("POST", "/agent_versions/v/chat/s/turn", bytes.NewReader(body))
+	r.SetPathValue("version_id", "v")
 	r.SetPathValue("session_id", "s")
 	w := httptest.NewRecorder()
 

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -19,12 +19,17 @@ import (
 )
 
 // ConfigStore is the narrow interface the configurator depends on.
+//
+// GetWithAgent returns both the version row (for status/bundle) and its owning
+// Agent (for name/flow_map_config). The flow-map config lives on the Agent
+// (per-agent), while status and bundle live on the AgentVersion. Other methods
+// are scoped: GetFlowMapConfig / UpdateFlowMapConfig take an agent_id;
+// UpdateStatus takes a version_id.
 type ConfigStore interface {
+	GetWithAgent(ctx context.Context, versionID string) (*types.AgentVersion, *types.Agent, error)
 	GetFlowMapConfig(ctx context.Context, agentID string) (cfg []byte, parseErr string, err error)
-	GetByID(ctx context.Context, id string) (*types.Agent, error)
-	AgentIDOf(ctx context.Context, versionID string) (string, error)
 	UpdateFlowMapConfig(ctx context.Context, agentID string, cfg []byte) error
-	UpdateStatus(ctx context.Context, agentID, expectedFrom, to string) error
+	UpdateStatus(ctx context.Context, versionID, expectedFrom, to string) error
 }
 
 type ConfiguratorHandler struct {
@@ -108,14 +113,15 @@ var proseRelLink = regexp.MustCompile(`\.\./(skills|capabilities|flows)/([^)\s]+
 
 // renderMarkdown converts a prose markdown blob (from the discovery
 // skill) to HTML. Relative links into the .flow-map directory layout
-// are rewritten to the agent's in-app configurator routes so they
-// actually navigate. Trusted input — prose is generated, not user-typed.
-func renderMarkdown(agentID, md string) template.HTML {
+// are rewritten to the configurator routes (scoped by version_id) so
+// they actually navigate. Trusted input — prose is generated, not
+// user-typed.
+func renderMarkdown(versionID, md string) template.HTML {
 	if md == "" {
 		return ""
 	}
-	if agentID != "" {
-		base := "/agents/" + agentID + "/configure/"
+	if versionID != "" {
+		base := "/agent_versions/" + versionID + "/configure/"
 		md = proseRelLink.ReplaceAllString(md, base+"$1/$2")
 	}
 	var buf bytes.Buffer
@@ -127,11 +133,11 @@ func renderMarkdown(agentID, md string) template.HTML {
 
 type configPageData struct {
 	Active            string
-	AgentID           string // version row's ID (URL path param semantics, legacy)
-	AgentRootID       string // stable agent ID, used for back-link
+	VersionID         string // URL path param value (a version row's ID)
+	AgentID           string // stable agent ID, used for back-link to the version list
 	AgentName         string
-	AgentStatus       string
-	ReadOnly          bool   // true for non-INITIALIZING agents (DRAFT, TRAINING, READY, DEPLOYED)
+	AgentStatus       string // version's status (lives on AgentVersion now)
+	ReadOnly          bool   // true for non-INITIALIZING versions (DRAFT, TRAINING, READY, DEPLOYED)
 	HasBundle         bool   // true when this version has a generated bundle (Run is enabled)
 	Tab               string // "flows" | "skills" | "capabilities" | "inputs"
 	Config            types.FlowMapConfig
@@ -154,16 +160,12 @@ type wizardFieldView struct {
 }
 
 func (h *ConfiguratorHandler) load(r *http.Request) (configPageData, error) {
-	agentID := r.PathValue("id")
-	agent, err := h.repo.GetByID(r.Context(), agentID)
+	versionID := r.PathValue("version_id")
+	version, agent, err := h.repo.GetWithAgent(r.Context(), versionID)
 	if err != nil {
 		return configPageData{}, err
 	}
-	rootID, err := h.repo.AgentIDOf(r.Context(), agentID)
-	if err != nil {
-		return configPageData{}, err
-	}
-	cfgBytes, parseErr, err := h.repo.GetFlowMapConfig(r.Context(), agentID)
+	cfgBytes, parseErr, err := h.repo.GetFlowMapConfig(r.Context(), agent.ID)
 	if err != nil {
 		return configPageData{}, err
 	}
@@ -175,12 +177,12 @@ func (h *ConfiguratorHandler) load(r *http.Request) (configPageData, error) {
 	}
 	return configPageData{
 		Active:            "agents",
-		AgentID:           agentID,
-		AgentRootID:       rootID,
+		VersionID:         versionID,
+		AgentID:           agent.ID,
 		AgentName:         agent.Name,
-		AgentStatus:       agent.Status,
-		ReadOnly:          agent.Status != "INITIALIZING",
-		HasBundle:         len(agent.Bundle) > 0,
+		AgentStatus:       version.Status,
+		ReadOnly:          version.Status != "INITIALIZING",
+		HasBundle:         len(version.Bundle) > 0,
 		Config:            cfg,
 		ParseError:        parseErr,
 		DiscoveryFilePath: agent.DiscoveryFilePath,
@@ -319,7 +321,7 @@ func (h *ConfiguratorHandler) Capabilities(w http.ResponseWriter, r *http.Reques
 // tplDict builds a map[string]any from alternating key/value template args.
 // Used to pass multiple named values into a sub-template invocation:
 //
-//	{{template "flow_row" (dict "AgentID" $.AgentID "Flow" .)}}
+//	{{template "flow_row" (dict "VersionID" $.VersionID "Flow" .)}}
 func tplDict(kv ...any) (map[string]any, error) {
 	if len(kv)%2 != 0 {
 		return nil, errors.New("dict: odd number of args")
@@ -335,19 +337,21 @@ func tplDict(kv ...any) (map[string]any, error) {
 	return m, nil
 }
 
-// requireEditable returns ErrInvalidAgentStatus if the agent isn't in
-// INITIALIZING — the only state where the configurator accepts edits.
-// Used as a guard at the top of every mutating handler so a stale tab
-// or a hand-crafted request can't change a finalized agent.
-func (h *ConfiguratorHandler) requireEditable(ctx context.Context, agentID string) error {
-	agent, err := h.repo.GetByID(ctx, agentID)
+// requireEditable resolves the version_id to the (version, agent) pair and
+// verifies the version is in INITIALIZING — the only state where the
+// configurator accepts edits. Returns the agent's stable ID so callers can
+// route subsequent config CRUD against the per-agent flow_map_config.
+// Used as a guard at the top of every mutating handler so a stale tab or
+// hand-crafted request can't change a finalized version.
+func (h *ConfiguratorHandler) requireEditable(ctx context.Context, versionID string) (agentID string, err error) {
+	version, agent, err := h.repo.GetWithAgent(ctx, versionID)
 	if err != nil {
-		return err
+		return "", err
 	}
-	if agent.Status != "INITIALIZING" {
-		return types.ErrInvalidAgentStatus
+	if version.Status != "INITIALIZING" {
+		return "", types.ErrInvalidAgentStatus
 	}
-	return nil
+	return agent.ID, nil
 }
 
 // loadConfig fetches the agent's flow_map_config and unmarshals into a
@@ -387,9 +391,10 @@ func (h *ConfiguratorHandler) FlowIncluded(w http.ResponseWriter, r *http.Reques
 	}
 	included := r.FormValue("included") == "true"
 
-	agentID := r.PathValue("id")
+	versionID := r.PathValue("version_id")
 	flowID := r.PathValue("flowId")
-	if err := h.requireEditable(r.Context(), agentID); err != nil {
+	agentID, err := h.requireEditable(r.Context(), versionID)
+	if err != nil {
 		Error(w, err)
 		return
 	}
@@ -417,9 +422,10 @@ func (h *ConfiguratorHandler) FlowIncluded(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Re-render the flow row so htmx can swap it in place.
+	// Re-render the flow row so htmx can swap it in place. Template's
+	// VersionID drives the htmx URL for the toggle/back actions.
 	renderTemplate(w, h.flowsTmpl, "flow_row", map[string]any{
-		"AgentID":    agentID,
+		"VersionID":  versionID,
 		"Flow":       cfg.Flows[idx],
 		"SelectedID": "",
 	})
@@ -483,8 +489,9 @@ func (h *ConfiguratorHandler) SkillCreate(w http.ResponseWriter, r *http.Request
 		http.Error(w, "invalid form", http.StatusBadRequest)
 		return
 	}
-	agentID := r.PathValue("id")
-	if err := h.requireEditable(r.Context(), agentID); err != nil {
+	versionID := r.PathValue("version_id")
+	agentID, err := h.requireEditable(r.Context(), versionID)
+	if err != nil {
 		Error(w, err)
 		return
 	}
@@ -523,7 +530,7 @@ func (h *ConfiguratorHandler) SkillCreate(w http.ResponseWriter, r *http.Request
 	}
 
 	renderTemplate(w, h.skillsTmpl, "skill_row", map[string]any{
-		"AgentID":    agentID,
+		"VersionID":  versionID,
 		"Skill":      parsed,
 		"SelectedID": "",
 	})
@@ -534,9 +541,10 @@ func (h *ConfiguratorHandler) SkillCreate(w http.ResponseWriter, r *http.Request
 // workflow (409). On success returns 200 with an empty body so htmx can
 // remove the row in place.
 func (h *ConfiguratorHandler) SkillDelete(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
+	versionID := r.PathValue("version_id")
 	skillID := r.PathValue("skillId")
-	if err := h.requireEditable(r.Context(), agentID); err != nil {
+	agentID, err := h.requireEditable(r.Context(), versionID)
+	if err != nil {
 		Error(w, err)
 		return
 	}
@@ -581,15 +589,20 @@ func (h *ConfiguratorHandler) SkillDelete(w http.ResponseWriter, r *http.Request
 // The form's submit URL is /skills (no skillId), creating a new row
 // instead of updating an existing one.
 func (h *ConfiguratorHandler) SkillNew(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	cfg, err := h.loadConfig(r.Context(), agentID)
+	versionID := r.PathValue("version_id")
+	_, agent, err := h.repo.GetWithAgent(r.Context(), versionID)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+	cfg, err := h.loadConfig(r.Context(), agent.ID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
 	blank := types.Skill{Origin: "custom", Role: "read"}
 	renderTemplate(w, h.skillsTmpl, "skill_new_form", map[string]any{
-		"AgentID":      agentID,
+		"VersionID":    versionID,
 		"Skill":        blank,
 		"Capabilities": cfg.Capabilities,
 	})
@@ -611,9 +624,10 @@ func (h *ConfiguratorHandler) WorkflowUpdate(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	agentID := r.PathValue("id")
+	versionID := r.PathValue("version_id")
 	flowID := r.PathValue("flowId")
-	if err := h.requireEditable(r.Context(), agentID); err != nil {
+	agentID, err := h.requireEditable(r.Context(), versionID)
+	if err != nil {
 		Error(w, err)
 		return
 	}
@@ -738,8 +752,8 @@ func tplWorkflowState(wf types.Workflow) (template.JS, error) {
 // in /agents/ui only appears for non-INITIALIZING agents). Returns 404 if
 // the agent doesn't exist or has no config persisted yet.
 func (h *ConfiguratorHandler) DownloadYAML(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	agent, err := h.repo.GetByID(r.Context(), agentID)
+	versionID := r.PathValue("version_id")
+	_, agent, err := h.repo.GetWithAgent(r.Context(), versionID)
 	if err != nil {
 		if errors.Is(err, types.ErrNotFound) {
 			http.NotFound(w, r)
@@ -748,7 +762,7 @@ func (h *ConfiguratorHandler) DownloadYAML(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	cfg, err := h.loadConfig(r.Context(), agentID)
+	cfg, err := h.loadConfig(r.Context(), agent.ID)
 	if err != nil {
 		if errors.Is(err, types.ErrNotFound) {
 			http.NotFound(w, r)
@@ -850,10 +864,10 @@ func sanitiseFilename(name string) string {
 
 // FinalizeConfirm renders the small confirmation page shown when the user
 // clicks "Finalize →" in the configurator. Submitting the page's form
-// POSTs to /agents/{id}/finalize.
+// POSTs to /agent_versions/{version_id}/finalize.
 func (h *ConfiguratorHandler) FinalizeConfirm(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	agent, err := h.repo.GetByID(r.Context(), agentID)
+	versionID := r.PathValue("version_id")
+	_, agent, err := h.repo.GetWithAgent(r.Context(), versionID)
 	if err != nil {
 		if errors.Is(err, types.ErrNotFound) {
 			http.NotFound(w, r)
@@ -862,14 +876,15 @@ func (h *ConfiguratorHandler) FinalizeConfirm(w http.ResponseWriter, r *http.Req
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	cfgBytes, parseErr, err := h.repo.GetFlowMapConfig(r.Context(), agentID)
+	cfgBytes, parseErr, err := h.repo.GetFlowMapConfig(r.Context(), agent.ID)
 	if err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 	data := configPageData{
 		Active:     "agents",
-		AgentID:    agentID,
+		VersionID:  versionID,
+		AgentID:    agent.ID,
 		AgentName:  agent.Name,
 		Tab:        "finalize",
 		ParseError: parseErr,
@@ -880,11 +895,11 @@ func (h *ConfiguratorHandler) FinalizeConfirm(w http.ResponseWriter, r *http.Req
 	renderTemplate(w, h.finalizeTmpl, "layout", data)
 }
 
-// Finalize flips status INITIALIZING → DRAFT and redirects to /agents/ui.
-// 409 (ErrInvalidAgentStatus) if the agent isn't in INITIALIZING.
+// Finalize flips the version's status INITIALIZING → DRAFT and redirects to
+// /agents/ui. 409 (ErrInvalidAgentStatus) if the version isn't in INITIALIZING.
 func (h *ConfiguratorHandler) Finalize(w http.ResponseWriter, r *http.Request) {
-	agentID := r.PathValue("id")
-	if err := h.repo.UpdateStatus(r.Context(), agentID, "INITIALIZING", "DRAFT"); err != nil {
+	versionID := r.PathValue("version_id")
+	if err := h.repo.UpdateStatus(r.Context(), versionID, "INITIALIZING", "DRAFT"); err != nil {
 		if errors.Is(err, types.ErrNotFound) {
 			http.NotFound(w, r)
 			return
@@ -901,9 +916,10 @@ func (h *ConfiguratorHandler) SkillUpdate(w http.ResponseWriter, r *http.Request
 		http.Error(w, "invalid form", http.StatusBadRequest)
 		return
 	}
-	agentID := r.PathValue("id")
+	versionID := r.PathValue("version_id")
 	skillID := r.PathValue("skillId")
-	if err := h.requireEditable(r.Context(), agentID); err != nil {
+	agentID, err := h.requireEditable(r.Context(), versionID)
+	if err != nil {
 		Error(w, err)
 		return
 	}
@@ -953,7 +969,7 @@ func (h *ConfiguratorHandler) SkillUpdate(w http.ResponseWriter, r *http.Request
 
 	// Re-render skill_detail so the htmx swap shows the saved state.
 	renderTemplate(w, h.skillsTmpl, "skill_detail", map[string]any{
-		"AgentID":      agentID,
+		"VersionID":    versionID,
 		"Skill":        *cur,
 		"Capabilities": cfg.Capabilities,
 	})

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -20,15 +20,14 @@ import (
 
 // ConfigStore is the narrow interface the configurator depends on.
 //
-// GetWithAgent returns both the version row (for status/bundle) and its owning
-// Agent (for name/flow_map_config). The flow-map config lives on the Agent
-// (per-agent), while status and bundle live on the AgentVersion. Other methods
-// are scoped: GetFlowMapConfig / UpdateFlowMapConfig take an agent_id;
-// UpdateStatus takes a version_id.
+// GetWithAgent returns both the version row (for status/bundle/flow_map_config)
+// and its owning Agent (for display fields like name + discovery file path).
+// All other methods are scoped per-version: flow_map_config, parse error,
+// and lifecycle status all live on AgentVersion after migration 014.
 type ConfigStore interface {
 	GetWithAgent(ctx context.Context, versionID string) (*types.AgentVersion, *types.Agent, error)
-	GetFlowMapConfig(ctx context.Context, agentID string) (cfg []byte, parseErr string, err error)
-	UpdateFlowMapConfig(ctx context.Context, agentID string, cfg []byte) error
+	GetFlowMapConfig(ctx context.Context, versionID string) (cfg []byte, parseErr string, err error)
+	UpdateFlowMapConfig(ctx context.Context, versionID string, cfg []byte) error
 	UpdateStatus(ctx context.Context, versionID, expectedFrom, to string) error
 }
 
@@ -165,7 +164,7 @@ func (h *ConfiguratorHandler) load(r *http.Request) (configPageData, error) {
 	if err != nil {
 		return configPageData{}, err
 	}
-	cfgBytes, parseErr, err := h.repo.GetFlowMapConfig(r.Context(), agent.ID)
+	cfgBytes, parseErr, err := h.repo.GetFlowMapConfig(r.Context(), version.ID)
 	if err != nil {
 		return configPageData{}, err
 	}
@@ -339,26 +338,26 @@ func tplDict(kv ...any) (map[string]any, error) {
 
 // requireEditable resolves the version_id to the (version, agent) pair and
 // verifies the version is in INITIALIZING — the only state where the
-// configurator accepts edits. Returns the agent's stable ID so callers can
-// route subsequent config CRUD against the per-agent flow_map_config.
-// Used as a guard at the top of every mutating handler so a stale tab or
-// hand-crafted request can't change a finalized version.
-func (h *ConfiguratorHandler) requireEditable(ctx context.Context, versionID string) (agentID string, err error) {
-	version, agent, err := h.repo.GetWithAgent(ctx, versionID)
+// configurator accepts edits. Returns the version's ID so callers can route
+// subsequent config CRUD against the per-version flow_map_config. Used as a
+// guard at the top of every mutating handler so a stale tab or hand-crafted
+// request can't change a finalized version.
+func (h *ConfiguratorHandler) requireEditable(ctx context.Context, versionID string) (string, error) {
+	version, _, err := h.repo.GetWithAgent(ctx, versionID)
 	if err != nil {
 		return "", err
 	}
 	if version.Status != "INITIALIZING" {
 		return "", types.ErrInvalidAgentStatus
 	}
-	return agent.ID, nil
+	return version.ID, nil
 }
 
-// loadConfig fetches the agent's flow_map_config and unmarshals into a
-// FlowMapConfig. Returns ErrNotFound if the agent does not exist or has no
+// loadConfig fetches the version's flow_map_config and unmarshals into a
+// FlowMapConfig. Returns ErrNotFound if the version does not exist or has no
 // config persisted (the configurator pages assume the wizard already ran).
-func (h *ConfiguratorHandler) loadConfig(ctx context.Context, agentID string) (types.FlowMapConfig, error) {
-	cfgBytes, _, err := h.repo.GetFlowMapConfig(ctx, agentID)
+func (h *ConfiguratorHandler) loadConfig(ctx context.Context, versionID string) (types.FlowMapConfig, error) {
+	cfgBytes, _, err := h.repo.GetFlowMapConfig(ctx, versionID)
 	if err != nil {
 		return types.FlowMapConfig{}, err
 	}
@@ -373,12 +372,12 @@ func (h *ConfiguratorHandler) loadConfig(ctx context.Context, agentID string) (t
 }
 
 // saveConfig marshals cfg to JSON and writes it via the repository.
-func (h *ConfiguratorHandler) saveConfig(ctx context.Context, agentID string, cfg types.FlowMapConfig) error {
+func (h *ConfiguratorHandler) saveConfig(ctx context.Context, versionID string, cfg types.FlowMapConfig) error {
 	b, err := json.Marshal(cfg)
 	if err != nil {
 		return err
 	}
-	return h.repo.UpdateFlowMapConfig(ctx, agentID, b)
+	return h.repo.UpdateFlowMapConfig(ctx, versionID, b)
 }
 
 // FlowIncluded toggles a flow's `included` boolean. Body: "included=true"
@@ -393,12 +392,12 @@ func (h *ConfiguratorHandler) FlowIncluded(w http.ResponseWriter, r *http.Reques
 
 	versionID := r.PathValue("version_id")
 	flowID := r.PathValue("flowId")
-	agentID, err := h.requireEditable(r.Context(), versionID)
+	vID, err := h.requireEditable(r.Context(), versionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
-	cfg, err := h.loadConfig(r.Context(), agentID)
+	cfg, err := h.loadConfig(r.Context(), vID)
 	if err != nil {
 		Error(w, err)
 		return
@@ -417,7 +416,7 @@ func (h *ConfiguratorHandler) FlowIncluded(w http.ResponseWriter, r *http.Reques
 	}
 	cfg.Flows[idx].Included = included
 
-	if err := h.saveConfig(r.Context(), agentID, cfg); err != nil {
+	if err := h.saveConfig(r.Context(), vID, cfg); err != nil {
 		Error(w, err)
 		return
 	}
@@ -490,12 +489,12 @@ func (h *ConfiguratorHandler) SkillCreate(w http.ResponseWriter, r *http.Request
 		return
 	}
 	versionID := r.PathValue("version_id")
-	agentID, err := h.requireEditable(r.Context(), versionID)
+	vID, err := h.requireEditable(r.Context(), versionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
-	cfg, err := h.loadConfig(r.Context(), agentID)
+	cfg, err := h.loadConfig(r.Context(), vID)
 	if err != nil {
 		Error(w, err)
 		return
@@ -524,7 +523,7 @@ func (h *ConfiguratorHandler) SkillCreate(w http.ResponseWriter, r *http.Request
 	parsed.Origin = "custom"
 
 	cfg.Skills = append(cfg.Skills, parsed)
-	if err := h.saveConfig(r.Context(), agentID, cfg); err != nil {
+	if err := h.saveConfig(r.Context(), vID, cfg); err != nil {
 		Error(w, err)
 		return
 	}
@@ -543,12 +542,12 @@ func (h *ConfiguratorHandler) SkillCreate(w http.ResponseWriter, r *http.Request
 func (h *ConfiguratorHandler) SkillDelete(w http.ResponseWriter, r *http.Request) {
 	versionID := r.PathValue("version_id")
 	skillID := r.PathValue("skillId")
-	agentID, err := h.requireEditable(r.Context(), versionID)
+	vID, err := h.requireEditable(r.Context(), versionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
-	cfg, err := h.loadConfig(r.Context(), agentID)
+	cfg, err := h.loadConfig(r.Context(), vID)
 	if err != nil {
 		Error(w, err)
 		return
@@ -577,7 +576,7 @@ func (h *ConfiguratorHandler) SkillDelete(w http.ResponseWriter, r *http.Request
 	}
 
 	cfg.Skills = append(cfg.Skills[:idx], cfg.Skills[idx+1:]...)
-	if err := h.saveConfig(r.Context(), agentID, cfg); err != nil {
+	if err := h.saveConfig(r.Context(), vID, cfg); err != nil {
 		Error(w, err)
 		return
 	}
@@ -590,12 +589,12 @@ func (h *ConfiguratorHandler) SkillDelete(w http.ResponseWriter, r *http.Request
 // instead of updating an existing one.
 func (h *ConfiguratorHandler) SkillNew(w http.ResponseWriter, r *http.Request) {
 	versionID := r.PathValue("version_id")
-	_, agent, err := h.repo.GetWithAgent(r.Context(), versionID)
+	version, _, err := h.repo.GetWithAgent(r.Context(), versionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
-	cfg, err := h.loadConfig(r.Context(), agent.ID)
+	cfg, err := h.loadConfig(r.Context(), version.ID)
 	if err != nil {
 		Error(w, err)
 		return
@@ -626,12 +625,12 @@ func (h *ConfiguratorHandler) WorkflowUpdate(w http.ResponseWriter, r *http.Requ
 
 	versionID := r.PathValue("version_id")
 	flowID := r.PathValue("flowId")
-	agentID, err := h.requireEditable(r.Context(), versionID)
+	vID, err := h.requireEditable(r.Context(), versionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
-	cfg, err := h.loadConfig(r.Context(), agentID)
+	cfg, err := h.loadConfig(r.Context(), vID)
 	if err != nil {
 		Error(w, err)
 		return
@@ -667,7 +666,7 @@ func (h *ConfiguratorHandler) WorkflowUpdate(w http.ResponseWriter, r *http.Requ
 		Layout:  body.Layout,
 	}
 
-	if err := h.saveConfig(r.Context(), agentID, cfg); err != nil {
+	if err := h.saveConfig(r.Context(), vID, cfg); err != nil {
 		Error(w, err)
 		return
 	}
@@ -753,7 +752,7 @@ func tplWorkflowState(wf types.Workflow) (template.JS, error) {
 // the agent doesn't exist or has no config persisted yet.
 func (h *ConfiguratorHandler) DownloadYAML(w http.ResponseWriter, r *http.Request) {
 	versionID := r.PathValue("version_id")
-	_, agent, err := h.repo.GetWithAgent(r.Context(), versionID)
+	version, agent, err := h.repo.GetWithAgent(r.Context(), versionID)
 	if err != nil {
 		if errors.Is(err, types.ErrNotFound) {
 			http.NotFound(w, r)
@@ -762,7 +761,7 @@ func (h *ConfiguratorHandler) DownloadYAML(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	cfg, err := h.loadConfig(r.Context(), agent.ID)
+	cfg, err := h.loadConfig(r.Context(), version.ID)
 	if err != nil {
 		if errors.Is(err, types.ErrNotFound) {
 			http.NotFound(w, r)
@@ -867,7 +866,7 @@ func sanitiseFilename(name string) string {
 // POSTs to /agent_versions/{version_id}/finalize.
 func (h *ConfiguratorHandler) FinalizeConfirm(w http.ResponseWriter, r *http.Request) {
 	versionID := r.PathValue("version_id")
-	_, agent, err := h.repo.GetWithAgent(r.Context(), versionID)
+	version, agent, err := h.repo.GetWithAgent(r.Context(), versionID)
 	if err != nil {
 		if errors.Is(err, types.ErrNotFound) {
 			http.NotFound(w, r)
@@ -876,7 +875,7 @@ func (h *ConfiguratorHandler) FinalizeConfirm(w http.ResponseWriter, r *http.Req
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	cfgBytes, parseErr, err := h.repo.GetFlowMapConfig(r.Context(), agent.ID)
+	cfgBytes, parseErr, err := h.repo.GetFlowMapConfig(r.Context(), version.ID)
 	if err != nil {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
@@ -918,12 +917,12 @@ func (h *ConfiguratorHandler) SkillUpdate(w http.ResponseWriter, r *http.Request
 	}
 	versionID := r.PathValue("version_id")
 	skillID := r.PathValue("skillId")
-	agentID, err := h.requireEditable(r.Context(), versionID)
+	vID, err := h.requireEditable(r.Context(), versionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
-	cfg, err := h.loadConfig(r.Context(), agentID)
+	cfg, err := h.loadConfig(r.Context(), vID)
 	if err != nil {
 		Error(w, err)
 		return
@@ -962,7 +961,7 @@ func (h *ConfiguratorHandler) SkillUpdate(w http.ResponseWriter, r *http.Request
 	cur.ProposedTool = parsed.ProposedTool
 	cur.UserPhrases = parsed.UserPhrases
 
-	if err := h.saveConfig(r.Context(), agentID, cfg); err != nil {
+	if err := h.saveConfig(r.Context(), vID, cfg); err != nil {
 		Error(w, err)
 		return
 	}

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -26,7 +26,7 @@ type stubConfigStore struct {
 	currentStatus string // optional override; defaults to "INITIALIZING"
 }
 
-func (s *stubConfigStore) GetFlowMapConfig(ctx context.Context, agentID string) ([]byte, string, error) {
+func (s *stubConfigStore) GetFlowMapConfig(ctx context.Context, versionID string) ([]byte, string, error) {
 	if s.getErr != nil {
 		return nil, "", s.getErr
 	}
@@ -39,15 +39,15 @@ func (s *stubConfigStore) GetWithAgent(ctx context.Context, versionID string) (*
 	if status == "" {
 		status = "INITIALIZING"
 	}
-	// The stub treats the URL's version_id as ALSO being the agent_id so test
-	// fixtures don't have to thread two identifiers. Per-agent calls
-	// (GetFlowMapConfig / UpdateFlowMapConfig) ignore the id anyway.
+	// The stub uses the URL's version_id for both ids — there's only one
+	// config in this fake, and per-version calls (GetFlowMapConfig /
+	// UpdateFlowMapConfig) ignore the id anyway.
 	version := &types.AgentVersion{ID: versionID, AgentID: versionID, Status: status}
 	agent := &types.Agent{ID: versionID, Name: s.cfg.Name}
 	return version, agent, nil
 }
 
-func (s *stubConfigStore) UpdateFlowMapConfig(ctx context.Context, agentID string, cfg []byte) error {
+func (s *stubConfigStore) UpdateFlowMapConfig(ctx context.Context, versionID string, cfg []byte) error {
 	s.updates++
 	if s.updateFn != nil {
 		return s.updateFn(cfg)

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -22,7 +22,7 @@ type stubConfigStore struct {
 	parseErr      string
 	updates       int
 	updateFn      func(cfg []byte) error
-	statusFn      func(agentID, expectedFrom, to string) error
+	statusFn      func(versionID, expectedFrom, to string) error
 	currentStatus string // optional override; defaults to "INITIALIZING"
 }
 
@@ -34,16 +34,17 @@ func (s *stubConfigStore) GetFlowMapConfig(ctx context.Context, agentID string) 
 	return b, s.parseErr, nil
 }
 
-func (s *stubConfigStore) GetByID(ctx context.Context, id string) (*types.Agent, error) {
+func (s *stubConfigStore) GetWithAgent(ctx context.Context, versionID string) (*types.AgentVersion, *types.Agent, error) {
 	status := s.currentStatus
 	if status == "" {
 		status = "INITIALIZING"
 	}
-	return &types.Agent{ID: id, Name: s.cfg.Name, Status: status}, nil
-}
-
-func (s *stubConfigStore) AgentIDOf(ctx context.Context, versionID string) (string, error) {
-	return versionID, nil
+	// The stub treats the URL's version_id as ALSO being the agent_id so test
+	// fixtures don't have to thread two identifiers. Per-agent calls
+	// (GetFlowMapConfig / UpdateFlowMapConfig) ignore the id anyway.
+	version := &types.AgentVersion{ID: versionID, AgentID: versionID, Status: status}
+	agent := &types.Agent{ID: versionID, Name: s.cfg.Name}
+	return version, agent, nil
 }
 
 func (s *stubConfigStore) UpdateFlowMapConfig(ctx context.Context, agentID string, cfg []byte) error {
@@ -59,9 +60,9 @@ func (s *stubConfigStore) UpdateFlowMapConfig(ctx context.Context, agentID strin
 	return nil
 }
 
-func (s *stubConfigStore) UpdateStatus(ctx context.Context, agentID, expectedFrom, to string) error {
+func (s *stubConfigStore) UpdateStatus(ctx context.Context, versionID, expectedFrom, to string) error {
 	if s.statusFn != nil {
-		return s.statusFn(agentID, expectedFrom, to)
+		return s.statusFn(versionID, expectedFrom, to)
 	}
 	cur := s.currentStatus
 	if cur == "" {
@@ -110,8 +111,8 @@ func newConfigHandler(t *testing.T, getter handler.ConfigStore) *handler.Configu
 
 func TestConfigurator_FlowsTab_RendersFlowsList(t *testing.T) {
 	h := newConfigHandler(t, &stubConfigStore{cfg: sampleConfig()})
-	req := httptest.NewRequest(http.MethodGet, "/agents/abc/configure/flows", nil)
-	req.SetPathValue("id", "abc")
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/configure/flows", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.Flows(w, req)
 	if w.Code != http.StatusOK {
@@ -129,8 +130,8 @@ func TestConfigurator_FlowsTab_NodeCountReflectsMermaid(t *testing.T) {
 		Mermaid: "flowchart TD\n  start([start]) --> s_po[place-order]\n  s_po --> e([end])\n",
 	}
 	h := newConfigHandler(t, &stubConfigStore{cfg: cfg})
-	req := httptest.NewRequest(http.MethodGet, "/agents/abc/configure/flows", nil)
-	req.SetPathValue("id", "abc")
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/configure/flows", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.Flows(w, req)
 	if w.Code != http.StatusOK {
@@ -143,8 +144,8 @@ func TestConfigurator_FlowsTab_NodeCountReflectsMermaid(t *testing.T) {
 
 func TestConfigurator_SkillsTab_ShowsSkillRow(t *testing.T) {
 	h := newConfigHandler(t, &stubConfigStore{cfg: sampleConfig()})
-	req := httptest.NewRequest(http.MethodGet, "/agents/abc/configure/skills", nil)
-	req.SetPathValue("id", "abc")
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/configure/skills", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.Skills(w, req)
 	if w.Code != http.StatusOK {
@@ -157,8 +158,8 @@ func TestConfigurator_SkillsTab_ShowsSkillRow(t *testing.T) {
 
 func TestConfigurator_CapabilitiesTab_IsReadOnly(t *testing.T) {
 	h := newConfigHandler(t, &stubConfigStore{cfg: sampleConfig()})
-	req := httptest.NewRequest(http.MethodGet, "/agents/abc/configure/capabilities", nil)
-	req.SetPathValue("id", "abc")
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/configure/capabilities", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.Capabilities(w, req)
 	if w.Code != http.StatusOK {
@@ -172,8 +173,8 @@ func TestConfigurator_CapabilitiesTab_IsReadOnly(t *testing.T) {
 
 func TestConfigurator_ParseError_ShowsErrorBanner(t *testing.T) {
 	h := newConfigHandler(t, &stubConfigStore{cfg: sampleConfig(), parseErr: "missing tools-proposed.json"})
-	req := httptest.NewRequest(http.MethodGet, "/agents/abc/configure", nil)
-	req.SetPathValue("id", "abc")
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/configure", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.Index(w, req)
 	if w.Code != http.StatusOK {
@@ -190,10 +191,10 @@ func TestConfigurator_FlowIncluded_Toggle(t *testing.T) {
 
 	// Toggle off
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/flows/place-order/included",
+		"/agent_versions/abc/configure/flows/place-order/included",
 		strings.NewReader("included=false"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("flowId", "place-order")
 	w := httptest.NewRecorder()
 	h.FlowIncluded(w, req)
@@ -210,10 +211,10 @@ func TestConfigurator_FlowIncluded_Toggle(t *testing.T) {
 
 	// Toggle back on.
 	req2 := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/flows/place-order/included",
+		"/agent_versions/abc/configure/flows/place-order/included",
 		strings.NewReader("included=true"))
 	req2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req2.SetPathValue("id", "abc")
+	req2.SetPathValue("version_id", "abc")
 	req2.SetPathValue("flowId", "place-order")
 	w2 := httptest.NewRecorder()
 	h.FlowIncluded(w2, req2)
@@ -229,10 +230,10 @@ func TestConfigurator_FlowIncluded_UnknownFlow_404(t *testing.T) {
 	store := &stubConfigStore{cfg: sampleConfig()}
 	h := newConfigHandler(t, store)
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/flows/ghost/included",
+		"/agent_versions/abc/configure/flows/ghost/included",
 		strings.NewReader("included=false"))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("flowId", "ghost")
 	w := httptest.NewRecorder()
 	h.FlowIncluded(w, req)
@@ -255,10 +256,10 @@ func TestConfigurator_SkillUpdate_HappyPath(t *testing.T) {
 		"external":      {"false"},
 	}
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/skills/place-order",
+		"/agent_versions/abc/configure/skills/place-order",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("skillId", "place-order")
 	w := httptest.NewRecorder()
 	h.SkillUpdate(w, req)
@@ -289,10 +290,10 @@ func TestConfigurator_SkillUpdate_External(t *testing.T) {
 		"user_phrases":  {""},
 	}
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/skills/place-order",
+		"/agent_versions/abc/configure/skills/place-order",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("skillId", "place-order")
 	w := httptest.NewRecorder()
 	h.SkillUpdate(w, req)
@@ -317,10 +318,10 @@ func TestConfigurator_SkillUpdate_InvalidRole(t *testing.T) {
 		"role": {"banana"}, // invalid
 	}
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/skills/place-order",
+		"/agent_versions/abc/configure/skills/place-order",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("skillId", "place-order")
 	w := httptest.NewRecorder()
 	h.SkillUpdate(w, req)
@@ -342,10 +343,10 @@ func TestConfigurator_SkillCreate_HappyPath(t *testing.T) {
 		"user_phrases":  {"send email\nemail me"},
 	}
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/skills",
+		"/agent_versions/abc/configure/skills",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.SkillCreate(w, req)
 	if w.Code != http.StatusOK {
@@ -379,10 +380,10 @@ func TestConfigurator_SkillCreate_NameCollision_GetsDiscriminator(t *testing.T) 
 		"external": {"true"},
 	}
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/skills",
+		"/agent_versions/abc/configure/skills",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.SkillCreate(w, req)
 	if w.Code != http.StatusOK {
@@ -400,10 +401,10 @@ func TestConfigurator_SkillCreate_NameRequired(t *testing.T) {
 
 	form := url.Values{"role": {"write"}, "external": {"true"}}
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/skills",
+		"/agent_versions/abc/configure/skills",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.SkillCreate(w, req)
 	if w.Code != http.StatusBadRequest {
@@ -421,8 +422,8 @@ func TestConfigurator_SkillDelete_Custom_OK(t *testing.T) {
 	h := newConfigHandler(t, store)
 
 	req := httptest.NewRequest(http.MethodDelete,
-		"/agents/abc/configure/skills/custom-thing", nil)
-	req.SetPathValue("id", "abc")
+		"/agent_versions/abc/configure/skills/custom-thing", nil)
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("skillId", "custom-thing")
 	w := httptest.NewRecorder()
 	h.SkillDelete(w, req)
@@ -441,8 +442,8 @@ func TestConfigurator_SkillDelete_Discovered_409(t *testing.T) {
 	h := newConfigHandler(t, store)
 
 	req := httptest.NewRequest(http.MethodDelete,
-		"/agents/abc/configure/skills/place-order", nil)
-	req.SetPathValue("id", "abc")
+		"/agent_versions/abc/configure/skills/place-order", nil)
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("skillId", "place-order")
 	w := httptest.NewRecorder()
 	h.SkillDelete(w, req)
@@ -465,8 +466,8 @@ func TestConfigurator_SkillDelete_Referenced_409(t *testing.T) {
 	h := newConfigHandler(t, store)
 
 	req := httptest.NewRequest(http.MethodDelete,
-		"/agents/abc/configure/skills/needed-by-flow", nil)
-	req.SetPathValue("id", "abc")
+		"/agent_versions/abc/configure/skills/needed-by-flow", nil)
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("skillId", "needed-by-flow")
 	w := httptest.NewRecorder()
 	h.SkillDelete(w, req)
@@ -484,10 +485,10 @@ func TestConfigurator_WorkflowUpdate_HappyPath(t *testing.T) {
 		"layout": {"start": {"x": 40, "y": 40}, "s_x": {"x": 40, "y": 140}, "e": {"x": 40, "y": 240}}
 	}`
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/flows/place-order/workflow",
+		"/agent_versions/abc/configure/flows/place-order/workflow",
 		strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("flowId", "place-order")
 	w := httptest.NewRecorder()
 	h.WorkflowUpdate(w, req)
@@ -513,10 +514,10 @@ func TestConfigurator_WorkflowUpdate_RejectsUnknownSkill(t *testing.T) {
 		"layout": {}
 	}`
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/flows/place-order/workflow",
+		"/agent_versions/abc/configure/flows/place-order/workflow",
 		strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("flowId", "place-order")
 	w := httptest.NewRecorder()
 	h.WorkflowUpdate(w, req)
@@ -532,10 +533,10 @@ func TestConfigurator_WorkflowUpdate_RejectsMalformedMermaid(t *testing.T) {
 
 	body := `{"mermaid": "this is not mermaid", "layout": {}}`
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/flows/place-order/workflow",
+		"/agent_versions/abc/configure/flows/place-order/workflow",
 		strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("flowId", "place-order")
 	w := httptest.NewRecorder()
 	h.WorkflowUpdate(w, req)
@@ -551,10 +552,10 @@ func TestConfigurator_WorkflowUpdate_UnknownFlow_404(t *testing.T) {
 
 	body := `{"mermaid": "flowchart TD\n  start([start]) --> e([end])", "layout": {}}`
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/configure/flows/ghost/workflow",
+		"/agent_versions/abc/configure/flows/ghost/workflow",
 		strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.SetPathValue("id", "abc")
+	req.SetPathValue("version_id", "abc")
 	req.SetPathValue("flowId", "ghost")
 	w := httptest.NewRecorder()
 	h.WorkflowUpdate(w, req)
@@ -576,8 +577,8 @@ func TestConfigurator_FinalizeConfirm_RendersPage(t *testing.T) {
 	h := newConfigHandler(t, store)
 
 	req := httptest.NewRequest(http.MethodGet,
-		"/agents/abc/configure/finalize", nil)
-	req.SetPathValue("id", "abc")
+		"/agent_versions/abc/configure/finalize", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.FinalizeConfirm(w, req)
 
@@ -588,7 +589,7 @@ func TestConfigurator_FinalizeConfirm_RendersPage(t *testing.T) {
 	if !strings.Contains(body, "Finalize") {
 		t.Errorf("response should contain a Finalize heading or button: first 200 chars = %s", body[:minInt(200, len(body))])
 	}
-	if !strings.Contains(body, "/agents/abc/finalize") {
+	if !strings.Contains(body, "/agent_versions/abc/finalize") {
 		t.Errorf("response should include the POST target: first 200 chars = %s", body[:minInt(200, len(body))])
 	}
 }
@@ -598,8 +599,8 @@ func TestConfigurator_Finalize_HappyPath_RedirectsToAgentsUI(t *testing.T) {
 	h := newConfigHandler(t, store)
 
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/finalize", nil)
-	req.SetPathValue("id", "abc")
+		"/agent_versions/abc/finalize", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.Finalize(w, req)
 
@@ -619,8 +620,8 @@ func TestConfigurator_Finalize_WrongStatus_409(t *testing.T) {
 	h := newConfigHandler(t, store)
 
 	req := httptest.NewRequest(http.MethodPost,
-		"/agents/abc/finalize", nil)
-	req.SetPathValue("id", "abc")
+		"/agent_versions/abc/finalize", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.Finalize(w, req)
 
@@ -633,8 +634,8 @@ func TestConfigurator_DownloadYAML_HappyPath(t *testing.T) {
 	store := &stubConfigStore{cfg: sampleConfig(), currentStatus: "DRAFT"}
 	h := newConfigHandler(t, store)
 
-	req := httptest.NewRequest(http.MethodGet, "/agents/abc/config.yaml", nil)
-	req.SetPathValue("id", "abc")
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/config.yaml", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.DownloadYAML(w, req)
 
@@ -664,8 +665,8 @@ func TestConfigurator_DownloadYAML_RoundTrip(t *testing.T) {
 	store := &stubConfigStore{cfg: cfg, currentStatus: "DRAFT"}
 	h := newConfigHandler(t, store)
 
-	req := httptest.NewRequest(http.MethodGet, "/agents/abc/config.yaml", nil)
-	req.SetPathValue("id", "abc")
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/config.yaml", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.DownloadYAML(w, req)
 	if w.Code != http.StatusOK {
@@ -710,8 +711,8 @@ func TestConfigurator_DownloadYAML_NoBlockScalarIndentIndicators(t *testing.T) {
 	store := &stubConfigStore{cfg: cfg, currentStatus: "DRAFT"}
 	h := newConfigHandler(t, store)
 
-	req := httptest.NewRequest(http.MethodGet, "/agents/abc/config.yaml", nil)
-	req.SetPathValue("id", "abc")
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/config.yaml", nil)
+	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
 	h.DownloadYAML(w, req)
 	if w.Code != http.StatusOK {
@@ -785,8 +786,8 @@ func TestConfigurator_DownloadYAML_CleanDropsExcludedAndOrphans(t *testing.T) {
 	h := newConfigHandler(t, store)
 
 	// Default (no clean=true): full content preserved.
-	reqFull := httptest.NewRequest(http.MethodGet, "/agents/abc/config.yaml", nil)
-	reqFull.SetPathValue("id", "abc")
+	reqFull := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/config.yaml", nil)
+	reqFull.SetPathValue("version_id", "abc")
 	wFull := httptest.NewRecorder()
 	h.DownloadYAML(wFull, reqFull)
 	var full types.FlowMapConfig
@@ -801,8 +802,8 @@ func TestConfigurator_DownloadYAML_CleanDropsExcludedAndOrphans(t *testing.T) {
 	}
 
 	// ?clean=true: filtered.
-	reqClean := httptest.NewRequest(http.MethodGet, "/agents/abc/config.yaml?clean=true", nil)
-	reqClean.SetPathValue("id", "abc")
+	reqClean := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/config.yaml?clean=true", nil)
+	reqClean.SetPathValue("version_id", "abc")
 	wClean := httptest.NewRecorder()
 	h.DownloadYAML(wClean, reqClean)
 	var clean types.FlowMapConfig

--- a/open-bbcd/internal/handler/deploy.go
+++ b/open-bbcd/internal/handler/deploy.go
@@ -8,59 +8,112 @@ import (
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
 )
 
-// DeployAgentRepository is the narrow agent interface DeployHandler needs.
+// DeployAgentRepository is the narrow per-agent dependency.
 type DeployAgentRepository interface {
-	GetByID(ctx context.Context, id string) (*types.Agent, error)
+	GetByID(ctx context.Context, agentID string) (*types.Agent, error)
+}
+
+// DeployVersionRepository is the narrow per-version dependency.
+type DeployVersionRepository interface {
+	GetByID(ctx context.Context, versionID string) (*types.AgentVersion, error)
 	Deploy(ctx context.Context, versionID string) (*string, error)
 	Undeploy(ctx context.Context, versionID string) error
+	CurrentDeployedID(ctx context.Context, agentID string) (string, error)
 }
 
 type DeployHandler struct {
-	repo DeployAgentRepository
+	agents   DeployAgentRepository
+	versions DeployVersionRepository
 }
 
-func NewDeployHandler(repo DeployAgentRepository) *DeployHandler {
-	return &DeployHandler{repo: repo}
+func NewDeployHandler(agents DeployAgentRepository, versions DeployVersionRepository) *DeployHandler {
+	return &DeployHandler{agents: agents, versions: versions}
+}
+
+type deployBody struct {
+	VersionID string `json:"version_id"`
 }
 
 type deployResponse struct {
-	Agent                     *types.Agent `json:"agent"`
-	PreviousDeployedVersionID *string      `json:"previous_deployed_version_id"`
+	Agent                     *types.Agent        `json:"agent"`
+	Version                   *types.AgentVersion `json:"version"`
+	PreviousDeployedVersionID *string             `json:"previous_deployed_version_id"`
 }
 
-// Deploy promotes a version to DEPLOYED, rotating any other deployed version
-// in the same chain to READY. Returns 200 with {agent, previous_deployed_version_id}.
-// 409 if the version is not READY. Idempotent on already-DEPLOYED versions
-// (returns 200 with previous_deployed_version_id = null).
+// Deploy handles POST /agents/{agent_id}/deploy with body {"version_id":"..."}.
+// Returns 200 with {agent, version, previous_deployed_version_id}.
+// 400 if version_id is missing. 404 if the version doesn't belong to the agent
+// or doesn't exist. 409 if the version is not READY.
 func (h *DeployHandler) Deploy(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
-	prev, err := h.repo.Deploy(r.Context(), id)
+	agentID := r.PathValue("agent_id")
+	var body deployBody
+	if err := DecodeJSON(r, &body); err != nil {
+		Error(w, err)
+		return
+	}
+	if body.VersionID == "" {
+		http.Error(w, "version_id is required", http.StatusBadRequest)
+		return
+	}
+
+	// Verify the version belongs to this agent before mutating.
+	version, err := h.versions.GetByID(r.Context(), body.VersionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
-	updated, err := h.repo.GetByID(r.Context(), id)
+	if version.AgentID != agentID {
+		Error(w, types.ErrNotFound)
+		return
+	}
+
+	prev, err := h.versions.Deploy(r.Context(), body.VersionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
+
+	updatedAgent, err := h.agents.GetByID(r.Context(), agentID)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+	updatedVersion, err := h.versions.GetByID(r.Context(), body.VersionID)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(deployResponse{Agent: updated, PreviousDeployedVersionID: prev})
+	_ = json.NewEncoder(w).Encode(deployResponse{
+		Agent:                     updatedAgent,
+		Version:                   updatedVersion,
+		PreviousDeployedVersionID: prev,
+	})
 }
 
-// Undeploy demotes a DEPLOYED version to READY. Returns 200 with the updated
-// Agent JSON; 409 if not currently deployed; 404 if missing.
+// Undeploy handles POST /agents/{agent_id}/undeploy. Takes the currently-
+// deployed version of the agent offline. Returns 409 if nothing is deployed.
 func (h *DeployHandler) Undeploy(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
-	if err := h.repo.Undeploy(r.Context(), id); err != nil {
+	agentID := r.PathValue("agent_id")
+	curID, err := h.versions.CurrentDeployedID(r.Context(), agentID)
+	if err != nil {
 		Error(w, err)
 		return
 	}
-	updated, err := h.repo.GetByID(r.Context(), id)
+	if curID == "" {
+		Error(w, types.ErrAgentNotDeployed)
+		return
+	}
+	if err := h.versions.Undeploy(r.Context(), curID); err != nil {
+		Error(w, err)
+		return
+	}
+	updatedAgent, err := h.agents.GetByID(r.Context(), agentID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(updated)
+	_ = json.NewEncoder(w).Encode(updatedAgent)
 }

--- a/open-bbcd/internal/handler/deploy_test.go
+++ b/open-bbcd/internal/handler/deploy_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -10,144 +11,161 @@ import (
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
 )
 
-// stubDeployRepo implements DeployAgentRepository in memory.
-type stubDeployRepo struct {
-	agent         *types.Agent
+type stubDeployAgentRepo struct {
+	agent  *types.Agent
+	getErr error
+}
+
+func (s *stubDeployAgentRepo) GetByID(ctx context.Context, agentID string) (*types.Agent, error) {
+	return s.agent, s.getErr
+}
+
+type stubDeployVersionRepo struct {
+	version       *types.AgentVersion
 	getErr        error
 	deployErr     error
 	undeployErr   error
 	prev          *string
 	deployCalls   int
 	undeployCalls int
+	currentID     string
+	currentErr    error
 }
 
-func (s *stubDeployRepo) GetByID(ctx context.Context, id string) (*types.Agent, error) {
-	return s.agent, s.getErr
+func (s *stubDeployVersionRepo) GetByID(ctx context.Context, versionID string) (*types.AgentVersion, error) {
+	return s.version, s.getErr
 }
-func (s *stubDeployRepo) Deploy(ctx context.Context, versionID string) (*string, error) {
+func (s *stubDeployVersionRepo) Deploy(ctx context.Context, versionID string) (*string, error) {
 	s.deployCalls++
 	if s.deployErr != nil {
 		return nil, s.deployErr
 	}
-	if s.agent != nil {
-		s.agent.Status = string(types.AgentStatusDeployed)
+	if s.version != nil {
+		s.version.Status = string(types.AgentStatusDeployed)
 	}
 	return s.prev, nil
 }
-func (s *stubDeployRepo) Undeploy(ctx context.Context, versionID string) error {
+func (s *stubDeployVersionRepo) Undeploy(ctx context.Context, versionID string) error {
 	s.undeployCalls++
 	if s.undeployErr != nil {
 		return s.undeployErr
 	}
-	if s.agent != nil {
-		s.agent.Status = string(types.AgentStatusReady)
+	if s.version != nil {
+		s.version.Status = string(types.AgentStatusReady)
 	}
 	return nil
 }
+func (s *stubDeployVersionRepo) CurrentDeployedID(ctx context.Context, agentID string) (string, error) {
+	return s.currentID, s.currentErr
+}
 
-func newDeployMux(repo DeployAgentRepository) *http.ServeMux {
-	h := NewDeployHandler(repo)
+func newDeployMux(agents DeployAgentRepository, versions DeployVersionRepository) *http.ServeMux {
+	h := NewDeployHandler(agents, versions)
 	mux := http.NewServeMux()
-	mux.HandleFunc("POST /agents/{id}/deploy", h.Deploy)
-	mux.HandleFunc("POST /agents/{id}/undeploy", h.Undeploy)
+	mux.HandleFunc("POST /agents/{agent_id}/deploy", h.Deploy)
+	mux.HandleFunc("POST /agents/{agent_id}/undeploy", h.Undeploy)
 	return mux
 }
 
 func TestDeployHandler_HappyPath(t *testing.T) {
-	repo := &stubDeployRepo{
-		agent: &types.Agent{ID: "v1", AgentID: "v1", Status: "READY"},
-	}
-	mux := newDeployMux(repo)
-
-	req := httptest.NewRequest("POST", "/agents/v1/deploy", nil)
+	agent := &types.Agent{ID: "a1", Name: "test"}
+	version := &types.AgentVersion{ID: "v1", AgentID: "a1", Status: "READY"}
+	mux := newDeployMux(
+		&stubDeployAgentRepo{agent: agent},
+		&stubDeployVersionRepo{version: version},
+	)
+	body, _ := json.Marshal(deployBody{VersionID: "v1"})
+	req := httptest.NewRequest("POST", "/agents/a1/deploy", bytes.NewReader(body))
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
-
 	if rr.Code != http.StatusOK {
 		t.Fatalf("got %d, body: %s", rr.Code, rr.Body.String())
 	}
-	var body struct {
-		Agent                     types.Agent `json:"agent"`
-		PreviousDeployedVersionID *string     `json:"previous_deployed_version_id"`
+	var resp deployResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp.Version.Status != "DEPLOYED" {
+		t.Fatalf("version status %q", resp.Version.Status)
 	}
-	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode: %v", err)
+}
+
+func TestDeployHandler_MissingVersionID_400(t *testing.T) {
+	mux := newDeployMux(&stubDeployAgentRepo{agent: &types.Agent{ID: "a1"}}, &stubDeployVersionRepo{})
+	req := httptest.NewRequest("POST", "/agents/a1/deploy", bytes.NewReader([]byte(`{}`)))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("got %d", rr.Code)
 	}
-	if body.Agent.Status != "DEPLOYED" {
-		t.Fatalf("status: %q", body.Agent.Status)
-	}
-	if body.PreviousDeployedVersionID != nil {
-		t.Fatalf("expected nil prev, got %v", body.PreviousDeployedVersionID)
-	}
-	if repo.deployCalls != 1 {
-		t.Fatalf("deploy calls = %d", repo.deployCalls)
+}
+
+func TestDeployHandler_WrongAgent_404(t *testing.T) {
+	version := &types.AgentVersion{ID: "v1", AgentID: "a2", Status: "READY"} // different agent
+	mux := newDeployMux(&stubDeployAgentRepo{agent: &types.Agent{ID: "a1"}}, &stubDeployVersionRepo{version: version})
+	body, _ := json.Marshal(deployBody{VersionID: "v1"})
+	req := httptest.NewRequest("POST", "/agents/a1/deploy", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("got %d", rr.Code)
 	}
 }
 
 func TestDeployHandler_NotDeployable_409(t *testing.T) {
-	repo := &stubDeployRepo{
-		agent:     &types.Agent{ID: "v1", AgentID: "v1", Status: "DRAFT"},
-		deployErr: types.ErrAgentNotDeployable,
-	}
-	mux := newDeployMux(repo)
-
+	version := &types.AgentVersion{ID: "v1", AgentID: "a1", Status: "DRAFT"}
+	mux := newDeployMux(
+		&stubDeployAgentRepo{agent: &types.Agent{ID: "a1"}},
+		&stubDeployVersionRepo{version: version, deployErr: types.ErrAgentNotDeployable},
+	)
+	body, _ := json.Marshal(deployBody{VersionID: "v1"})
+	req := httptest.NewRequest("POST", "/agents/a1/deploy", bytes.NewReader(body))
 	rr := httptest.NewRecorder()
-	mux.ServeHTTP(rr, httptest.NewRequest("POST", "/agents/v1/deploy", nil))
+	mux.ServeHTTP(rr, req)
 	if rr.Code != http.StatusConflict {
-		t.Fatalf("got %d, body: %s", rr.Code, rr.Body.String())
+		t.Fatalf("got %d", rr.Code)
 	}
 }
 
 func TestDeployHandler_ReportsPreviousDeployed(t *testing.T) {
 	prev := "v-old"
-	repo := &stubDeployRepo{
-		agent: &types.Agent{ID: "v2", AgentID: "v1", Status: "READY"},
-		prev:  &prev,
-	}
-	mux := newDeployMux(repo)
-
+	version := &types.AgentVersion{ID: "v2", AgentID: "a1", Status: "READY"}
+	mux := newDeployMux(
+		&stubDeployAgentRepo{agent: &types.Agent{ID: "a1"}},
+		&stubDeployVersionRepo{version: version, prev: &prev},
+	)
+	body, _ := json.Marshal(deployBody{VersionID: "v2"})
+	req := httptest.NewRequest("POST", "/agents/a1/deploy", bytes.NewReader(body))
 	rr := httptest.NewRecorder()
-	mux.ServeHTTP(rr, httptest.NewRequest("POST", "/agents/v2/deploy", nil))
-	if rr.Code != http.StatusOK {
-		t.Fatalf("got %d", rr.Code)
-	}
-	var body struct {
-		Agent                     types.Agent `json:"agent"`
-		PreviousDeployedVersionID *string     `json:"previous_deployed_version_id"`
-	}
-	_ = json.Unmarshal(rr.Body.Bytes(), &body)
-	if body.PreviousDeployedVersionID == nil || *body.PreviousDeployedVersionID != prev {
-		t.Fatalf("prev=%v want %q", body.PreviousDeployedVersionID, prev)
+	mux.ServeHTTP(rr, req)
+	var resp deployResponse
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp.PreviousDeployedVersionID == nil || *resp.PreviousDeployedVersionID != prev {
+		t.Fatalf("prev=%v want %q", resp.PreviousDeployedVersionID, prev)
 	}
 }
 
 func TestUndeployHandler_HappyPath(t *testing.T) {
-	repo := &stubDeployRepo{
-		agent: &types.Agent{ID: "v1", AgentID: "v1", Status: "DEPLOYED"},
-	}
-	mux := newDeployMux(repo)
-
+	agent := &types.Agent{ID: "a1"}
+	version := &types.AgentVersion{ID: "v1", AgentID: "a1", Status: "DEPLOYED"}
+	mux := newDeployMux(
+		&stubDeployAgentRepo{agent: agent},
+		&stubDeployVersionRepo{version: version, currentID: "v1"},
+	)
+	req := httptest.NewRequest("POST", "/agents/a1/undeploy", nil)
 	rr := httptest.NewRecorder()
-	mux.ServeHTTP(rr, httptest.NewRequest("POST", "/agents/v1/undeploy", nil))
+	mux.ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("got %d body=%s", rr.Code, rr.Body.String())
 	}
-	var ag types.Agent
-	_ = json.Unmarshal(rr.Body.Bytes(), &ag)
-	if ag.Status != "READY" {
-		t.Fatalf("status: %q", ag.Status)
-	}
 }
 
-func TestUndeployHandler_NotDeployed_409(t *testing.T) {
-	repo := &stubDeployRepo{
-		agent:       &types.Agent{ID: "v1", AgentID: "v1", Status: "DRAFT"},
-		undeployErr: types.ErrAgentNotDeployed,
-	}
-	mux := newDeployMux(repo)
-
+func TestUndeployHandler_NoneDeployed_409(t *testing.T) {
+	mux := newDeployMux(
+		&stubDeployAgentRepo{agent: &types.Agent{ID: "a1"}},
+		&stubDeployVersionRepo{currentID: ""}, // none deployed
+	)
+	req := httptest.NewRequest("POST", "/agents/a1/undeploy", nil)
 	rr := httptest.NewRecorder()
-	mux.ServeHTTP(rr, httptest.NewRequest("POST", "/agents/v1/undeploy", nil))
+	mux.ServeHTTP(rr, req)
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("got %d", rr.Code)
 	}

--- a/open-bbcd/internal/handler/deployed.go
+++ b/open-bbcd/internal/handler/deployed.go
@@ -15,7 +15,7 @@ import (
 
 // DeployedAgentReader is the narrow interface the deployed handler needs.
 type DeployedAgentReader interface {
-	CurrentDeployedVersionID(ctx context.Context, agentID string) (string, error)
+	CurrentDeployedID(ctx context.Context, agentID string) (string, error)
 }
 
 // DeployedStore is the narrow repo interface for deployed sessions/messages.
@@ -58,7 +58,7 @@ func NewDeployedHandler(
 // Returns (versionID, true) if a version is deployed; ("", false) and a
 // 404 written to w if no version is deployed (no existence leak).
 func (h *DeployedHandler) requireDeployed(w http.ResponseWriter, r *http.Request, agentID string) (string, bool) {
-	v, err := h.agents.CurrentDeployedVersionID(r.Context(), agentID)
+	v, err := h.agents.CurrentDeployedID(r.Context(), agentID)
 	if err != nil {
 		Error(w, err)
 		return "", false

--- a/open-bbcd/internal/handler/deployed_test.go
+++ b/open-bbcd/internal/handler/deployed_test.go
@@ -20,7 +20,7 @@ type stubDeployedAgentReader struct {
 	err        error
 }
 
-func (s *stubDeployedAgentReader) CurrentDeployedVersionID(ctx context.Context, agentID string) (string, error) {
+func (s *stubDeployedAgentReader) CurrentDeployedID(ctx context.Context, agentID string) (string, error) {
 	return s.deployedID, s.err
 }
 

--- a/open-bbcd/internal/handler/ui.go
+++ b/open-bbcd/internal/handler/ui.go
@@ -16,7 +16,6 @@ import (
 type GroupedAgentRepository interface {
 	ListGrouped(ctx context.Context) ([]types.AgentGroup, error)
 	GetByID(ctx context.Context, id string) (*types.Agent, error)
-	CurrentDeployedVersionID(ctx context.Context, agentID string) (string, error)
 }
 
 type UIHandler struct {

--- a/open-bbcd/internal/handler/ui.go
+++ b/open-bbcd/internal/handler/ui.go
@@ -21,6 +21,7 @@ type GroupedAgentRepository interface {
 
 type UIHandler struct {
 	agentRepo         GroupedAgentRepository
+	versions          DeployVersionRepository
 	schema            *types.WizardSchema
 	logger            *slog.Logger
 	agentsTmpl        *template.Template
@@ -46,7 +47,7 @@ func statusClass(status string) string {
 	}
 }
 
-func NewUIHandler(agentRepo GroupedAgentRepository, schema *types.WizardSchema, webFS fs.FS, logger *slog.Logger) (*UIHandler, error) {
+func NewUIHandler(agentRepo GroupedAgentRepository, versions DeployVersionRepository, schema *types.WizardSchema, webFS fs.FS, logger *slog.Logger) (*UIHandler, error) {
 	funcs := template.FuncMap{
 		"statusClass": statusClass,
 		"add":         func(a, b int) int { return a + b },
@@ -100,6 +101,7 @@ func NewUIHandler(agentRepo GroupedAgentRepository, schema *types.WizardSchema, 
 
 	return &UIHandler{
 		agentRepo:         agentRepo,
+		versions:          versions,
 		schema:            schema,
 		logger:            logger,
 		agentsTmpl:        agentsTmpl,
@@ -144,6 +146,7 @@ func (h *UIHandler) AgentsPage(w http.ResponseWriter, r *http.Request) {
 			if group.AgentID == agentID {
 				renderTemplate(w, h.agentVersionsTmpl, "layout", agentVersionsPageData{
 					Active:   "agents",
+					AgentID:  group.AgentID,
 					Name:     group.Name,
 					Versions: group.Versions,
 				})
@@ -159,8 +162,9 @@ func (h *UIHandler) AgentsPage(w http.ResponseWriter, r *http.Request) {
 
 type agentVersionsPageData struct {
 	Active   string
+	AgentID  string
 	Name     string
-	Versions []types.AgentVersion
+	Versions []types.AgentVersionListItem
 }
 
 type wizardPageData struct {
@@ -224,44 +228,58 @@ func (h *UIHandler) WizardStep(w http.ResponseWriter, r *http.Request) {
 	renderTemplate(w, h.stepTmpl, "step", data)
 }
 
-type deployModalData struct {
-	Version         *types.Agent
-	AgentID     string
-	CurrentDeployed *types.Agent // nil if no current deploy or self
-}
-
 // DeployConfirm renders the deploy confirmation modal partial for one version.
 func (u *UIHandler) DeployConfirm(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
-	ver, err := u.agentRepo.GetByID(r.Context(), id)
+	agentID := r.PathValue("agent_id")
+	versionID := r.URL.Query().Get("version_id")
+	if versionID == "" {
+		http.Error(w, "version_id query param required", http.StatusBadRequest)
+		return
+	}
+	version, err := u.versions.GetByID(r.Context(), versionID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
-	curID, err := u.agentRepo.CurrentDeployedVersionID(r.Context(), ver.AgentID)
+	if version.AgentID != agentID {
+		http.NotFound(w, r)
+		return
+	}
+	curID, err := u.versions.CurrentDeployedID(r.Context(), agentID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
-	var cur *types.Agent
-	if curID != "" && curID != ver.ID {
-		cur, _ = u.agentRepo.GetByID(r.Context(), curID)
+	var current *types.AgentVersion
+	if curID != "" && curID != versionID {
+		current, _ = u.versions.GetByID(r.Context(), curID)
 	}
-	renderTemplate(w, u.deployModalTmpl, "agent-deploy-modal", deployModalData{
-		Version: ver, AgentID: ver.AgentID, CurrentDeployed: cur,
-	})
+	renderTemplate(w, u.deployModalTmpl, "agent-deploy-modal", struct {
+		AgentID         string
+		Version         *types.AgentVersion
+		CurrentDeployed *types.AgentVersion
+	}{agentID, version, current})
 }
 
 // UndeployConfirm renders the undeploy confirmation modal partial.
 func (u *UIHandler) UndeployConfirm(w http.ResponseWriter, r *http.Request) {
-	id := r.PathValue("id")
-	ver, err := u.agentRepo.GetByID(r.Context(), id)
+	agentID := r.PathValue("agent_id")
+	curID, err := u.versions.CurrentDeployedID(r.Context(), agentID)
+	if err != nil {
+		Error(w, err)
+		return
+	}
+	if curID == "" {
+		Error(w, types.ErrAgentNotDeployed)
+		return
+	}
+	cur, err := u.versions.GetByID(r.Context(), curID)
 	if err != nil {
 		Error(w, err)
 		return
 	}
 	renderTemplate(w, u.undeployModalTmpl, "agent-undeploy-modal", struct {
-		Version     *types.Agent
 		AgentID string
-	}{ver, ver.AgentID})
+		Version *types.AgentVersion
+	}{agentID, cur})
 }

--- a/open-bbcd/internal/handler/wizard.go
+++ b/open-bbcd/internal/handler/wizard.go
@@ -17,7 +17,7 @@ import (
 )
 
 type WizardAgentRepository interface {
-	CreateFromWizard(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error)
+	CreateFromWizard(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error)
 }
 
 type WizardHandler struct {
@@ -126,7 +126,7 @@ func (h *WizardHandler) Submit(w http.ResponseWriter, r *http.Request) {
 		cfgJSON = b
 	}
 
-	agent, err := h.agentRepo.CreateFromWizard(r.Context(), types.CreateAgentFromWizardOpts{
+	_, version, err := h.agentRepo.CreateFromWizard(r.Context(), types.CreateAgentFromWizardOpts{
 		ID:                agentID,
 		Name:              wizardInput["name"],
 		FlowMapConfig:     cfgJSON,
@@ -143,5 +143,5 @@ func (h *WizardHandler) Submit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.Redirect(w, r, "/agents/"+agent.ID+"/configure", http.StatusSeeOther)
+	http.Redirect(w, r, "/agent_versions/"+version.ID+"/configure", http.StatusSeeOther)
 }

--- a/open-bbcd/internal/handler/wizard_test.go
+++ b/open-bbcd/internal/handler/wizard_test.go
@@ -42,10 +42,10 @@ wizard:
 `
 
 type mockWizardRepo struct {
-	createFromWizardFn func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error)
+	createFromWizardFn func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error)
 }
 
-func (m *mockWizardRepo) CreateFromWizard(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
+func (m *mockWizardRepo) CreateFromWizard(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error) {
 	return m.createFromWizardFn(ctx, opts)
 }
 
@@ -105,9 +105,11 @@ func buildWizardForm(t *testing.T, fields map[string]string, fileName string, fi
 func TestWizardHandler_Submit_HappyPath(t *testing.T) {
 	var capturedOpts types.CreateAgentFromWizardOpts
 	repo := &mockWizardRepo{
-		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
+		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error) {
 			capturedOpts = opts
-			return &types.Agent{ID: opts.ID, Name: opts.Name, Status: "INITIALIZING"}, nil
+			return &types.Agent{ID: opts.ID, Name: opts.Name},
+				&types.AgentVersion{ID: "v-" + opts.ID, AgentID: opts.ID, Status: "INITIALIZING"},
+				nil
 		},
 	}
 	var capturedKey string
@@ -135,8 +137,8 @@ func TestWizardHandler_Submit_HappyPath(t *testing.T) {
 		t.Fatalf("status = %d, want 303; body = %s", w.Code, w.Body.String())
 	}
 	loc := w.Header().Get("Location")
-	if !strings.HasPrefix(loc, "/agents/") || !strings.HasSuffix(loc, "/configure") {
-		t.Errorf("Location = %q, want /agents/<id>/configure", loc)
+	if !strings.HasPrefix(loc, "/agent_versions/") || !strings.HasSuffix(loc, "/configure") {
+		t.Errorf("Location = %q, want /agent_versions/<id>/configure", loc)
 	}
 	if store.calls != 1 {
 		t.Errorf("store.Put called %d times, want 1", store.calls)
@@ -159,9 +161,9 @@ func TestWizardHandler_Submit_HappyPath(t *testing.T) {
 
 func TestWizardHandler_Submit_MissingFile(t *testing.T) {
 	repo := &mockWizardRepo{
-		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
+		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error) {
 			t.Fatal("repo should not be called")
-			return nil, nil
+			return nil, nil, nil
 		},
 	}
 	store := &mockStorage{}
@@ -187,9 +189,9 @@ func TestWizardHandler_Submit_MissingFile(t *testing.T) {
 
 func TestWizardHandler_Submit_BadExtension(t *testing.T) {
 	repo := &mockWizardRepo{
-		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
+		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error) {
 			t.Fatal("repo should not be called")
-			return nil, nil
+			return nil, nil, nil
 		},
 	}
 	store := &mockStorage{}
@@ -215,9 +217,9 @@ func TestWizardHandler_Submit_BadExtension(t *testing.T) {
 
 func TestWizardHandler_Submit_TooLarge(t *testing.T) {
 	repo := &mockWizardRepo{
-		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
+		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error) {
 			t.Fatal("repo should not be called")
-			return nil, nil
+			return nil, nil, nil
 		},
 	}
 	store := &mockStorage{}
@@ -249,9 +251,9 @@ func TestWizardHandler_Submit_TooLarge(t *testing.T) {
 
 func TestWizardHandler_Submit_StorageFails(t *testing.T) {
 	repo := &mockWizardRepo{
-		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
+		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error) {
 			t.Fatal("repo should not be called when storage fails")
-			return nil, nil
+			return nil, nil, nil
 		},
 	}
 	store := &mockStorage{
@@ -282,8 +284,8 @@ func TestWizardHandler_Submit_RepoFailLogsOrphan(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
 
 	repo := &mockWizardRepo{
-		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
-			return nil, errors.New("db down")
+		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error) {
+			return nil, nil, errors.New("db down")
 		},
 	}
 	var savedKey string
@@ -321,9 +323,9 @@ func TestWizardHandler_Submit_RepoFailLogsOrphan(t *testing.T) {
 
 func TestWizardHandler_Submit_MissingName(t *testing.T) {
 	repo := &mockWizardRepo{
-		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
+		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error) {
 			t.Fatal("repo should not be called when name is empty")
-			return nil, nil
+			return nil, nil, nil
 		},
 	}
 	store := &mockStorage{}
@@ -353,9 +355,11 @@ func TestWizardHandler_Submit_RealZip_HappyPath(t *testing.T) {
 
 	var capturedOpts types.CreateAgentFromWizardOpts
 	repo := &mockWizardRepo{
-		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
+		createFromWizardFn: func(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error) {
 			capturedOpts = opts
-			return &types.Agent{ID: opts.ID, Name: opts.Name, Status: "INITIALIZING"}, nil
+			return &types.Agent{ID: opts.ID, Name: opts.Name},
+				&types.AgentVersion{ID: "v-" + opts.ID, AgentID: opts.ID, Status: "INITIALIZING"},
+				nil
 		},
 	}
 	store := &mockStorage{}

--- a/open-bbcd/internal/repository/agent.go
+++ b/open-bbcd/internal/repository/agent.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"sort"
 
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
@@ -20,341 +19,231 @@ func NewAgentRepository(db *sql.DB) *AgentRepository {
 	return &AgentRepository{db: db}
 }
 
-type scanner interface {
-	Scan(dest ...any) error
-}
+const agentColumns = `id, name, description, flow_map_config, flow_map_parse_error, discovery_file_path, created_at`
 
 func scanAgent(s scanner) (*types.Agent, error) {
-	agent := &types.Agent{}
+	a := &types.Agent{}
 	var description sql.NullString
-	var bundle []byte
-	var parentVersionID sql.NullString
-	var flowMapConfig []byte
-	var flowMapParseError sql.NullString
-	var discoveryFilePath sql.NullString
-	err := s.Scan(
-		&agent.ID,
-		&agent.AgentID,
-		&agent.Name,
-		&description,
-		&bundle,
-		&agent.Status,
-		&parentVersionID,
-		&flowMapConfig,
-		&flowMapParseError,
-		&discoveryFilePath,
-		&agent.CreatedAt,
-		&agent.UpdatedAt,
-	)
-	if err != nil {
+	var cfg []byte
+	var parseErr sql.NullString
+	var disc sql.NullString
+	if err := s.Scan(&a.ID, &a.Name, &description, &cfg, &parseErr, &disc, &a.CreatedAt); err != nil {
 		return nil, err
 	}
-	agent.Description = description.String
-	agent.Bundle = bundle
-	if parentVersionID.Valid {
-		agent.ParentVersionID = &parentVersionID.String
-	}
-	agent.FlowMapConfig = flowMapConfig
-	if flowMapParseError.Valid {
-		agent.FlowMapParseError = flowMapParseError.String
-	}
-	if discoveryFilePath.Valid {
-		agent.DiscoveryFilePath = discoveryFilePath.String
-	}
-	return agent, nil
+	a.Description = description.String
+	a.FlowMapConfig = cfg
+	a.FlowMapParseError = parseErr.String
+	a.DiscoveryFilePath = disc.String
+	return a, nil
 }
 
-// agentColumns lists the SELECT/RETURNING columns. Must stay in sync with
-// scanAgent's positional scan destinations.
-const agentColumns = `id, agent_id, name, description, bundle, status, parent_version_id, flow_map_config, flow_map_parse_error, discovery_file_path, created_at, updated_at`
-
+// Create inserts an Agent (REST path).
 func (r *AgentRepository) Create(ctx context.Context, opts types.CreateAgentOpts) (*types.Agent, error) {
-	agent, err := types.NewAgent(opts)
+	a, err := types.NewAgent(opts)
 	if err != nil {
 		return nil, err
 	}
 	id := uuid.NewString()
 	row := r.db.QueryRowContext(ctx, `
-		INSERT INTO agents (id, agent_id, name, description)
-		VALUES ($1::uuid, $1::uuid, $2, $3)
+		INSERT INTO agents (id, name, description)
+		VALUES ($1::uuid, $2, $3)
 		RETURNING `+agentColumns,
-		id, agent.Name, agent.Description,
+		id, a.Name, a.Description,
 	)
 	return scanAgent(row)
 }
 
-func (r *AgentRepository) GetByID(ctx context.Context, id string) (*types.Agent, error) {
-	row := r.db.QueryRowContext(ctx, `
-		SELECT `+agentColumns+` FROM agents WHERE id = $1
-	`, id)
-	agent, err := scanAgent(row)
+// CreateFromWizard inserts an agents row + an INITIALIZING agent_versions row
+// in a single transaction. Returns both. The version's id is auto-generated;
+// opts.ID, if set, becomes the agent's id.
+func (r *AgentRepository) CreateFromWizard(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, *types.AgentVersion, error) {
+	if opts.Name == "" {
+		return nil, nil, types.ErrNameRequired
+	}
+	if r.db == nil {
+		return nil, nil, errors.New("repository: no database connection")
+	}
+	agentID := opts.ID
+	if agentID == "" {
+		agentID = uuid.NewString()
+	}
+	versionID := uuid.NewString()
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	agentRow := tx.QueryRowContext(ctx, `
+		INSERT INTO agents (id, name, flow_map_config, flow_map_parse_error, discovery_file_path)
+		VALUES ($1::uuid, $2, $3, NULLIF($4, ''), NULLIF($5, ''))
+		RETURNING `+agentColumns,
+		agentID, opts.Name, []byte(opts.FlowMapConfig), opts.FlowMapParseError, opts.DiscoveryFilePath,
+	)
+	agent, err := scanAgent(agentRow)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	versionRow := tx.QueryRowContext(ctx, `
+		INSERT INTO agent_versions (id, agent_id, status)
+		VALUES ($1::uuid, $2::uuid, 'INITIALIZING')
+		RETURNING `+agentVersionColumns,
+		versionID, agentID,
+	)
+	version, err := scanAgentVersion(versionRow)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, nil, err
+	}
+	return agent, version, nil
+}
+
+// GetByID returns the Agent (per-agent row).
+func (r *AgentRepository) GetByID(ctx context.Context, agentID string) (*types.Agent, error) {
+	row := r.db.QueryRowContext(ctx, `SELECT `+agentColumns+` FROM agents WHERE id = $1`, agentID)
+	a, err := scanAgent(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, types.ErrNotFound
 	}
-	return agent, err
+	return a, err
 }
 
+// List returns all Agents (per-agent rows). Used by the JSON GET /agents endpoint.
 func (r *AgentRepository) List(ctx context.Context) ([]*types.Agent, error) {
-	rows, err := r.db.QueryContext(ctx, `
-		SELECT `+agentColumns+` FROM agents ORDER BY created_at DESC
-	`)
+	rows, err := r.db.QueryContext(ctx, `SELECT `+agentColumns+` FROM agents ORDER BY created_at`)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-
-	var agents []*types.Agent
+	var out []*types.Agent
 	for rows.Next() {
-		agent, err := scanAgent(rows)
+		a, err := scanAgent(rows)
 		if err != nil {
 			return nil, err
 		}
-		agents = append(agents, agent)
+		out = append(out, a)
 	}
-	return agents, rows.Err()
+	return out, rows.Err()
 }
 
-// ListGrouped fetches all agents and groups them into named version groups.
-// Within each chain, versions are ordered newest first. Version numbers are
-// computed from position in the parent_version_id linked list.
+// ListGrouped returns each Agent with its ordered versions. One LEFT JOIN.
 func (r *AgentRepository) ListGrouped(ctx context.Context) ([]types.AgentGroup, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT `+agentColumns+` FROM agents ORDER BY created_at ASC
+		SELECT a.id::text, a.name,
+		       av.id::text, av.agent_id::text, av.parent_version_id, av.status, av.bundle, av.created_at, av.updated_at
+		FROM agents a
+		LEFT JOIN agent_versions av ON av.agent_id = a.id
+		ORDER BY a.created_at, av.created_at
 	`)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var all []*types.Agent
-	byID := make(map[string]*types.Agent)
+	groupsByID := make(map[string]*types.AgentGroup)
+	var order []string
 	for rows.Next() {
-		agent, err := scanAgent(rows)
-		if err != nil {
+		var aID, aName string
+		var vID sql.NullString
+		var vAgentID sql.NullString
+		var vParent sql.NullString
+		var vStatus sql.NullString
+		var vBundle []byte
+		var vCreated, vUpdated sql.NullTime
+		if err := rows.Scan(&aID, &aName, &vID, &vAgentID, &vParent, &vStatus, &vBundle, &vCreated, &vUpdated); err != nil {
 			return nil, err
 		}
-		all = append(all, agent)
-		byID[agent.ID] = agent
+		g, ok := groupsByID[aID]
+		if !ok {
+			g = &types.AgentGroup{AgentID: aID, Name: aName}
+			groupsByID[aID] = g
+			order = append(order, aID)
+		}
+		if !vID.Valid {
+			continue // agent with no versions yet
+		}
+		v := &types.AgentVersion{
+			ID:        vID.String,
+			AgentID:   vAgentID.String,
+			Status:    vStatus.String,
+			Bundle:    vBundle,
+			CreatedAt: vCreated.Time,
+			UpdatedAt: vUpdated.Time,
+		}
+		if vParent.Valid {
+			v.ParentVersionID = &vParent.String
+		}
+		g.Versions = append(g.Versions, types.AgentVersionListItem{Version: v, VersionNum: 0})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
-	// Walk each agent up to its chain root.
-	rootOf := func(cur *types.Agent) string {
-		for cur.ParentVersionID != nil {
+	// Compute version numbers within each group by walking parent_version_id.
+	// Sort newest-first for display once numbers are set.
+	out := make([]types.AgentGroup, 0, len(order))
+	for _, aID := range order {
+		g := groupsByID[aID]
+		assignVersionNumbers(g)
+		sort.Slice(g.Versions, func(i, j int) bool {
+			return g.Versions[i].VersionNum > g.Versions[j].VersionNum
+		})
+		out = append(out, *g)
+	}
+	return out, nil
+}
+
+// assignVersionNumbers walks the parent_version_id chain inside one group and
+// assigns 1-based positional numbers (root = 1).
+func assignVersionNumbers(g *types.AgentGroup) {
+	byID := make(map[string]*types.AgentVersionListItem, len(g.Versions))
+	for i := range g.Versions {
+		byID[g.Versions[i].Version.ID] = &g.Versions[i]
+	}
+	for i := range g.Versions {
+		v := g.Versions[i].Version
+		num := 1
+		for cur := v; cur.ParentVersionID != nil; {
+			num++
 			parent, ok := byID[*cur.ParentVersionID]
 			if !ok {
 				break
 			}
-			cur = parent
+			cur = parent.Version
 		}
-		return cur.ID
+		g.Versions[i].VersionNum = num
 	}
-
-	type accumulator struct {
-		name     string
-		versions []*types.Agent // oldest first (creation order from query)
-	}
-	groupMap := make(map[string]*accumulator)
-	var rootOrder []string // preserves first-seen order for stable output
-
-	for _, a := range all {
-		rootID := rootOf(a)
-		if _, exists := groupMap[rootID]; !exists {
-			// Chain name is always the root agent's name; agent names are
-			// immutable per chain so this is stable across all versions.
-			groupMap[rootID] = &accumulator{name: byID[rootID].Name}
-			rootOrder = append(rootOrder, rootID)
-		}
-		groupMap[rootID].versions = append(groupMap[rootID].versions, a)
-	}
-
-	groups := make([]types.AgentGroup, 0, len(rootOrder))
-	for _, rootID := range rootOrder {
-		acc := groupMap[rootID]
-		versions := make([]types.AgentVersion, len(acc.versions))
-		for i, a := range acc.versions {
-			versions[i] = types.AgentVersion{Agent: a, VersionNum: i + 1}
-		}
-		// Reverse so newest version is first in the slice (for display).
-		sort.Slice(versions, func(i, j int) bool {
-			return versions[i].VersionNum > versions[j].VersionNum
-		})
-		groups = append(groups, types.AgentGroup{AgentID: rootID, Name: acc.name, Versions: versions})
-	}
-	return groups, nil
 }
 
-// AgentIDOf returns the stable agent ID for the given version row.
-// Returns ErrNotFound if the version row does not exist.
-func (r *AgentRepository) AgentIDOf(ctx context.Context, versionID string) (string, error) {
-	var agentID string
-	err := r.db.QueryRowContext(ctx,
-		`SELECT agent_id::text FROM agents WHERE id = $1`,
-		versionID,
-	).Scan(&agentID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", types.ErrNotFound
-	}
-	if err != nil {
-		return "", err
-	}
-	return agentID, nil
-}
-
-// Deploy promotes versionID to DEPLOYED, demoting any other version in the
-// same chain that is currently DEPLOYED. Returns the previously-deployed
-// version ID (if any) so callers can show "v3 was replaced by v4" UI.
-// Re-deploying an already-DEPLOYED version is a no-op success (prev is nil).
-func (r *AgentRepository) Deploy(ctx context.Context, versionID string) (*string, error) {
-	tx, err := r.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	var status, agentID string
-	err = tx.QueryRowContext(ctx,
-		`SELECT status, agent_id::text FROM agents WHERE id = $1`, versionID,
-	).Scan(&status, &agentID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, types.ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-	if status == string(types.AgentStatusDeployed) {
-		// No-op success. Commit (no-op) for symmetry.
-		if err := tx.Commit(); err != nil {
-			return nil, err
-		}
-		return nil, nil
-	}
-	if status != string(types.AgentStatusReady) {
-		return nil, types.ErrAgentNotDeployable
-	}
-
-	var prevID sql.NullString
-	err = tx.QueryRowContext(ctx, `
-		UPDATE agents SET status = 'READY', updated_at = now()
-		WHERE agent_id = $1 AND status = 'DEPLOYED' AND id != $2
-		RETURNING id::text
-	`, agentID, versionID).Scan(&prevID)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("demote previous: %w", err)
-	}
-
-	if _, err := tx.ExecContext(ctx,
-		`UPDATE agents SET status='DEPLOYED', updated_at = now() WHERE id = $1`, versionID,
-	); err != nil {
-		return nil, fmt.Errorf("promote target: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-	if prevID.Valid {
-		return &prevID.String, nil
-	}
-	return nil, nil
-}
-
-// Undeploy flips a DEPLOYED version back to READY. Returns ErrAgentNotDeployed
-// if the target is not currently DEPLOYED, ErrNotFound if it does not exist.
-func (r *AgentRepository) Undeploy(ctx context.Context, versionID string) error {
-	res, err := r.db.ExecContext(ctx,
-		`UPDATE agents SET status='READY', updated_at = now() WHERE id = $1 AND status = 'DEPLOYED'`,
-		versionID,
-	)
-	if err != nil {
-		return err
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if n == 0 {
-		// Disambiguate: missing row vs. wrong status.
-		var dummy string
-		err := r.db.QueryRowContext(ctx, `SELECT id::text FROM agents WHERE id=$1`, versionID).Scan(&dummy)
-		if errors.Is(err, sql.ErrNoRows) {
-			return types.ErrNotFound
-		}
-		if err != nil {
-			return err
-		}
-		return types.ErrAgentNotDeployed
-	}
-	return nil
-}
-
-// CurrentDeployedVersionID returns the ID of the version currently DEPLOYED in
-// the given chain, or "" if none. Indexed lookup via agents_one_deployed_per_chain.
-func (r *AgentRepository) CurrentDeployedVersionID(ctx context.Context, agentID string) (string, error) {
-	var id string
-	err := r.db.QueryRowContext(ctx,
-		`SELECT id::text FROM agents WHERE agent_id = $1 AND status = 'DEPLOYED'`,
-		agentID,
-	).Scan(&id)
-	if errors.Is(err, sql.ErrNoRows) {
-		return "", nil
-	}
-	if err != nil {
-		return "", err
-	}
-	return id, nil
-}
-
-// CreateFromWizard inserts an agent in INITIALIZING status from wizard form
-// answers. The agent's UUID and discovery-file key are pre-generated by the
-// caller so the file write happens before the row insert. opts.ID, when
-// non-empty, must be a valid UUID string (Postgres rejects malformed input).
-func (r *AgentRepository) CreateFromWizard(ctx context.Context, opts types.CreateAgentFromWizardOpts) (*types.Agent, error) {
-	if opts.Name == "" {
-		return nil, types.ErrNameRequired
-	}
-	if r.db == nil {
-		return nil, errors.New("repository: no database connection")
-	}
-	id := opts.ID
-	if id == "" {
-		id = uuid.NewString()
-	}
-	row := r.db.QueryRowContext(ctx, `
-		INSERT INTO agents (id, agent_id, name, status, flow_map_config, flow_map_parse_error, discovery_file_path)
-		VALUES ($1::uuid, $1::uuid, $2, 'INITIALIZING', $3, NULLIF($4, ''), NULLIF($5, ''))
-		RETURNING `+agentColumns,
-		id, opts.Name, []byte(opts.FlowMapConfig), opts.FlowMapParseError, opts.DiscoveryFilePath,
-	)
-	return scanAgent(row)
-}
-
-// GetFlowMapConfig returns the agent's parsed config (or nil bytes if absent).
-// Returns ErrNotFound if no agent has the given id.
+// GetFlowMapConfig returns the agent's flow_map_config + parse_error.
+// Returns ErrNotFound if the agent does not exist.
 func (r *AgentRepository) GetFlowMapConfig(ctx context.Context, agentID string) ([]byte, string, error) {
 	var cfg []byte
 	var parseErr sql.NullString
-	row := r.db.QueryRowContext(ctx, `
-		SELECT flow_map_config, flow_map_parse_error FROM agents WHERE id = $1
-	`, agentID)
-	if err := row.Scan(&cfg, &parseErr); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, "", types.ErrNotFound
-		}
+	err := r.db.QueryRowContext(ctx,
+		`SELECT flow_map_config, flow_map_parse_error FROM agents WHERE id = $1`,
+		agentID,
+	).Scan(&cfg, &parseErr)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, "", types.ErrNotFound
+	}
+	if err != nil {
 		return nil, "", err
 	}
 	return cfg, parseErr.String, nil
 }
 
-// UpdateFlowMapConfig overwrites the agent's flow_map_config and clears any
-// prior parse error. Used by configurator edit endpoints (PR2/PR3).
+// UpdateFlowMapConfig overwrites the agent's config in place. (Future: this
+// will spawn a new agent instead. Out of scope for this PR.)
 func (r *AgentRepository) UpdateFlowMapConfig(ctx context.Context, agentID string, cfg []byte) error {
-	res, err := r.db.ExecContext(ctx, `
-		UPDATE agents
-		SET flow_map_config = $2, flow_map_parse_error = NULL, updated_at = now()
-		WHERE id = $1
-	`, agentID, cfg)
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE agents SET flow_map_config = $2, flow_map_parse_error = NULL WHERE id = $1`,
+		agentID, cfg,
+	)
 	if err != nil {
 		return err
 	}
@@ -364,85 +253,6 @@ func (r *AgentRepository) UpdateFlowMapConfig(ctx context.Context, agentID strin
 	}
 	if n == 0 {
 		return types.ErrNotFound
-	}
-	return nil
-}
-
-// SetBundle writes the agent's bundle JSONB. Without force, refuses to
-// overwrite a non-NULL bundle (write-once enforcement). With force, overrides.
-// Returns ErrNotFound if the agent doesn't exist; ErrBundleAlreadySet if a
-// bundle exists and force is false.
-func (r *AgentRepository) SetBundle(ctx context.Context, agentID string, bundle []byte, force bool) error {
-	if force {
-		res, err := r.db.ExecContext(ctx, `
-			UPDATE agents SET bundle = $2, updated_at = now() WHERE id = $1
-		`, agentID, bundle)
-		if err != nil {
-			return err
-		}
-		n, err := res.RowsAffected()
-		if err != nil {
-			return err
-		}
-		if n == 0 {
-			return types.ErrNotFound
-		}
-		return nil
-	}
-	res, err := r.db.ExecContext(ctx, `
-		UPDATE agents SET bundle = $2, updated_at = now()
-		WHERE id = $1 AND bundle IS NULL
-	`, agentID, bundle)
-	if err != nil {
-		return err
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if n == 0 {
-		// Either not found, or bundle is already set.
-		var exists bool
-		if err := r.db.QueryRowContext(ctx,
-			`SELECT EXISTS (SELECT 1 FROM agents WHERE id = $1)`, agentID,
-		).Scan(&exists); err != nil {
-			return err
-		}
-		if !exists {
-			return types.ErrNotFound
-		}
-		return types.ErrBundleAlreadySet
-	}
-	return nil
-}
-
-// UpdateStatus transitions the agent's status. Used by Finalize
-// (INITIALIZING → DRAFT). Returns ErrInvalidAgentStatus if the current
-// status doesn't match expectedFrom — preventing accidental re-finalize.
-func (r *AgentRepository) UpdateStatus(ctx context.Context, agentID, expectedFrom, to string) error {
-	res, err := r.db.ExecContext(ctx, `
-		UPDATE agents
-		SET status = $3, updated_at = now()
-		WHERE id = $1 AND status = $2
-	`, agentID, expectedFrom, to)
-	if err != nil {
-		return err
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if n == 0 {
-		// Either the agent doesn't exist, or its status isn't expectedFrom.
-		var cur string
-		row := r.db.QueryRowContext(ctx, `SELECT status FROM agents WHERE id = $1`, agentID)
-		if err := row.Scan(&cur); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return types.ErrNotFound
-			}
-			return err
-		}
-		return fmt.Errorf("%w: have %q, want %q", types.ErrInvalidAgentStatus, cur, expectedFrom)
 	}
 	return nil
 }

--- a/open-bbcd/internal/repository/agent.go
+++ b/open-bbcd/internal/repository/agent.go
@@ -19,20 +19,16 @@ func NewAgentRepository(db *sql.DB) *AgentRepository {
 	return &AgentRepository{db: db}
 }
 
-const agentColumns = `id, name, description, flow_map_config, flow_map_parse_error, discovery_file_path, created_at`
+const agentColumns = `id, name, description, discovery_file_path, created_at`
 
 func scanAgent(s scanner) (*types.Agent, error) {
 	a := &types.Agent{}
 	var description sql.NullString
-	var cfg []byte
-	var parseErr sql.NullString
 	var disc sql.NullString
-	if err := s.Scan(&a.ID, &a.Name, &description, &cfg, &parseErr, &disc, &a.CreatedAt); err != nil {
+	if err := s.Scan(&a.ID, &a.Name, &description, &disc, &a.CreatedAt); err != nil {
 		return nil, err
 	}
 	a.Description = description.String
-	a.FlowMapConfig = cfg
-	a.FlowMapParseError = parseErr.String
 	a.DiscoveryFilePath = disc.String
 	return a, nil
 }
@@ -76,10 +72,10 @@ func (r *AgentRepository) CreateFromWizard(ctx context.Context, opts types.Creat
 	defer func() { _ = tx.Rollback() }()
 
 	agentRow := tx.QueryRowContext(ctx, `
-		INSERT INTO agents (id, name, flow_map_config, flow_map_parse_error, discovery_file_path)
-		VALUES ($1::uuid, $2, $3, NULLIF($4, ''), NULLIF($5, ''))
+		INSERT INTO agents (id, name, discovery_file_path)
+		VALUES ($1::uuid, $2, NULLIF($3, ''))
 		RETURNING `+agentColumns,
-		agentID, opts.Name, []byte(opts.FlowMapConfig), opts.FlowMapParseError, opts.DiscoveryFilePath,
+		agentID, opts.Name, opts.DiscoveryFilePath,
 	)
 	agent, err := scanAgent(agentRow)
 	if err != nil {
@@ -87,10 +83,10 @@ func (r *AgentRepository) CreateFromWizard(ctx context.Context, opts types.Creat
 	}
 
 	versionRow := tx.QueryRowContext(ctx, `
-		INSERT INTO agent_versions (id, agent_id, status)
-		VALUES ($1::uuid, $2::uuid, 'INITIALIZING')
+		INSERT INTO agent_versions (id, agent_id, status, flow_map_config, flow_map_parse_error)
+		VALUES ($1::uuid, $2::uuid, 'INITIALIZING', $3, NULLIF($4, ''))
 		RETURNING `+agentVersionColumns,
-		versionID, agentID,
+		versionID, agentID, []byte(opts.FlowMapConfig), opts.FlowMapParseError,
 	)
 	version, err := scanAgentVersion(versionRow)
 	if err != nil {
@@ -217,42 +213,4 @@ func assignVersionNumbers(g *types.AgentGroup) {
 		}
 		g.Versions[i].VersionNum = num
 	}
-}
-
-// GetFlowMapConfig returns the agent's flow_map_config + parse_error.
-// Returns ErrNotFound if the agent does not exist.
-func (r *AgentRepository) GetFlowMapConfig(ctx context.Context, agentID string) ([]byte, string, error) {
-	var cfg []byte
-	var parseErr sql.NullString
-	err := r.db.QueryRowContext(ctx,
-		`SELECT flow_map_config, flow_map_parse_error FROM agents WHERE id = $1`,
-		agentID,
-	).Scan(&cfg, &parseErr)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, "", types.ErrNotFound
-	}
-	if err != nil {
-		return nil, "", err
-	}
-	return cfg, parseErr.String, nil
-}
-
-// UpdateFlowMapConfig overwrites the agent's config in place. (Future: this
-// will spawn a new agent instead. Out of scope for this PR.)
-func (r *AgentRepository) UpdateFlowMapConfig(ctx context.Context, agentID string, cfg []byte) error {
-	res, err := r.db.ExecContext(ctx,
-		`UPDATE agents SET flow_map_config = $2, flow_map_parse_error = NULL WHERE id = $1`,
-		agentID, cfg,
-	)
-	if err != nil {
-		return err
-	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return err
-	}
-	if n == 0 {
-		return types.ErrNotFound
-	}
-	return nil
 }

--- a/open-bbcd/internal/repository/agent_test.go
+++ b/open-bbcd/internal/repository/agent_test.go
@@ -2,12 +2,9 @@ package repository
 
 import (
 	"context"
-	"database/sql"
-	"errors"
 	"testing"
 
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
-	"github.com/google/uuid"
 )
 
 func TestAgentRepository_Create_ValidationError(t *testing.T) {
@@ -21,221 +18,49 @@ func TestAgentRepository_Create_ValidationError(t *testing.T) {
 
 func TestAgentRepository_CreateFromWizard_ValidationError(t *testing.T) {
 	repo := NewAgentRepository(nil)
-	_, err := repo.CreateFromWizard(context.Background(), types.CreateAgentFromWizardOpts{Name: ""})
+	_, _, err := repo.CreateFromWizard(context.Background(), types.CreateAgentFromWizardOpts{Name: ""})
 	if err != types.ErrNameRequired {
 		t.Errorf("error = %v, want %v", err, types.ErrNameRequired)
 	}
 }
 
-func TestAgentRepository_Create_SetsAgentIDToSelf(t *testing.T) {
-	t.Parallel()
+func TestAgentRepository_Create_ReturnsAgent(t *testing.T) {
 	repo, _ := withRepo(t)
 	ctx := context.Background()
-
-	agent, err := repo.Create(ctx, types.CreateAgentOpts{Name: "deploy-test-1"})
+	a, err := repo.Create(ctx, types.CreateAgentOpts{Name: "create-test"})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if agent.AgentID != agent.ID {
-		t.Fatalf("expected agent_id == id, got agent_id=%q id=%q",
-			agent.AgentID, agent.ID)
+	if a.ID == "" {
+		t.Fatalf("ID empty")
+	}
+	if a.Name != "create-test" {
+		t.Fatalf("Name=%q", a.Name)
 	}
 }
 
-func TestAgentRepository_CreateFromWizard_SetsAgentIDToSelf(t *testing.T) {
-	t.Parallel()
-	repo, _ := withRepo(t)
+func TestAgentRepository_CreateFromWizard_CreatesAgentAndVersion(t *testing.T) {
+	repo, db := withRepo(t)
 	ctx := context.Background()
-
-	agent, err := repo.CreateFromWizard(ctx, types.CreateAgentFromWizardOpts{
-		Name: "deploy-test-2",
+	agent, version, err := repo.CreateFromWizard(ctx, types.CreateAgentFromWizardOpts{
+		Name: "wizard-test",
 	})
 	if err != nil {
 		t.Fatalf("CreateFromWizard: %v", err)
 	}
-	if agent.AgentID != agent.ID {
-		t.Fatalf("expected agent_id == id, got agent_id=%q id=%q",
-			agent.AgentID, agent.ID)
+	if agent.Name != "wizard-test" {
+		t.Fatalf("agent name=%q", agent.Name)
 	}
-}
-
-// helper: insert a READY child version under an existing chain root, bypassing
-// the configurator. Used only in repo tests.
-func insertReadyChildVersion(t *testing.T, db *sql.DB, parentID string) string {
-	t.Helper()
-	var rootID string
-	if err := db.QueryRow(`SELECT agent_id::text FROM agents WHERE id=$1`, parentID).Scan(&rootID); err != nil {
-		t.Fatalf("lookup root: %v", err)
+	if version.AgentID != agent.ID {
+		t.Fatalf("version.AgentID=%q want %q", version.AgentID, agent.ID)
 	}
-	id := uuid.NewString()
-	_, err := db.Exec(`
-		INSERT INTO agents (id, agent_id, name, status, parent_version_id, bundle)
-		SELECT $1::uuid, $2::uuid, name, 'READY', $3::uuid, '{}'::jsonb FROM agents WHERE id=$3::uuid
-	`, id, rootID, parentID)
-	if err != nil {
-		t.Fatalf("insert child: %v", err)
+	if version.Status != "INITIALIZING" {
+		t.Fatalf("version.Status=%q", version.Status)
 	}
-	return id
-}
-
-func TestAgentRepository_Deploy_HappyPath(t *testing.T) {
-	repo, db := withRepo(t)
-	ctx := context.Background()
-
-	root, err := repo.Create(ctx, types.CreateAgentOpts{Name: "deploy-happy"})
-	if err != nil {
-		t.Fatalf("Create: %v", err)
-	}
-	if _, err := db.ExecContext(ctx, `UPDATE agents SET status='READY' WHERE id=$1`, root.ID); err != nil {
-		t.Fatalf("seed READY: %v", err)
-	}
-
-	prev, err := repo.Deploy(ctx, root.ID)
-	if err != nil {
-		t.Fatalf("Deploy: %v", err)
-	}
-	if prev != nil {
-		t.Fatalf("expected nil prev (first deploy in chain), got %q", *prev)
-	}
-
-	after, err := repo.GetByID(ctx, root.ID)
-	if err != nil {
-		t.Fatalf("GetByID: %v", err)
-	}
-	if after.Status != string(types.AgentStatusDeployed) {
-		t.Fatalf("got status %q, want DEPLOYED", after.Status)
-	}
-}
-
-func TestAgentRepository_Deploy_Rotates(t *testing.T) {
-	repo, db := withRepo(t)
-	ctx := context.Background()
-
-	root, _ := repo.Create(ctx, types.CreateAgentOpts{Name: "deploy-rotate"})
-	_, _ = db.ExecContext(ctx, `UPDATE agents SET status='READY' WHERE id=$1`, root.ID)
-	_, _ = repo.Deploy(ctx, root.ID)
-
-	child := insertReadyChildVersion(t, db, root.ID)
-
-	prev, err := repo.Deploy(ctx, child)
-	if err != nil {
-		t.Fatalf("Deploy child: %v", err)
-	}
-	if prev == nil || *prev != root.ID {
-		t.Fatalf("expected prev=%q, got %v", root.ID, prev)
-	}
-
-	rootAfter, _ := repo.GetByID(ctx, root.ID)
-	childAfter, _ := repo.GetByID(ctx, child)
-	if rootAfter.Status != "READY" {
-		t.Fatalf("root status: got %q want READY", rootAfter.Status)
-	}
-	if childAfter.Status != "DEPLOYED" {
-		t.Fatalf("child status: got %q want DEPLOYED", childAfter.Status)
-	}
-}
-
-func TestAgentRepository_Deploy_NotDeployable(t *testing.T) {
-	repo, _ := withRepo(t)
-	ctx := context.Background()
-
-	root, _ := repo.Create(ctx, types.CreateAgentOpts{Name: "deploy-bad"})
-	// Default status is DRAFT — not deployable.
-
-	_, err := repo.Deploy(ctx, root.ID)
-	if !errors.Is(err, types.ErrAgentNotDeployable) {
-		t.Fatalf("got %v, want ErrAgentNotDeployable", err)
-	}
-}
-
-func TestAgentRepository_Deploy_Idempotent(t *testing.T) {
-	repo, db := withRepo(t)
-	ctx := context.Background()
-
-	root, _ := repo.Create(ctx, types.CreateAgentOpts{Name: "deploy-idem"})
-	_, _ = db.ExecContext(ctx, `UPDATE agents SET status='READY' WHERE id=$1`, root.ID)
-	_, _ = repo.Deploy(ctx, root.ID)
-
-	prev, err := repo.Deploy(ctx, root.ID)
-	if err != nil {
-		t.Fatalf("Deploy (again): %v", err)
-	}
-	if prev != nil {
-		t.Fatalf("expected nil prev on re-deploy, got %q", *prev)
-	}
-
-	after, _ := repo.GetByID(ctx, root.ID)
-	if after.Status != "DEPLOYED" {
-		t.Fatalf("status: got %q want DEPLOYED", after.Status)
-	}
-}
-
-func TestAgentRepository_Undeploy(t *testing.T) {
-	repo, db := withRepo(t)
-	ctx := context.Background()
-
-	root, _ := repo.Create(ctx, types.CreateAgentOpts{Name: "undeploy-test"})
-	_, _ = db.ExecContext(ctx, `UPDATE agents SET status='READY' WHERE id=$1`, root.ID)
-	_, _ = repo.Deploy(ctx, root.ID)
-
-	if err := repo.Undeploy(ctx, root.ID); err != nil {
-		t.Fatalf("Undeploy: %v", err)
-	}
-	after, _ := repo.GetByID(ctx, root.ID)
-	if after.Status != "READY" {
-		t.Fatalf("got %q, want READY", after.Status)
-	}
-
-	// Idempotency check — calling undeploy on a non-deployed should 409.
-	err := repo.Undeploy(ctx, root.ID)
-	if !errors.Is(err, types.ErrAgentNotDeployed) {
-		t.Fatalf("got %v, want ErrAgentNotDeployed", err)
-	}
-}
-
-func TestAgentRepository_CurrentDeployedVersionID(t *testing.T) {
-	repo, db := withRepo(t)
-	ctx := context.Background()
-
-	root, _ := repo.Create(ctx, types.CreateAgentOpts{Name: "deployed-lookup"})
-
-	// No deployed version yet.
-	id, err := repo.CurrentDeployedVersionID(ctx, root.ID)
-	if err != nil {
-		t.Fatalf("CurrentDeployedVersionID: %v", err)
-	}
-	if id != "" {
-		t.Fatalf("expected empty, got %q", id)
-	}
-
-	_, _ = db.ExecContext(ctx, `UPDATE agents SET status='READY' WHERE id=$1`, root.ID)
-	_, _ = repo.Deploy(ctx, root.ID)
-
-	id, err = repo.CurrentDeployedVersionID(ctx, root.ID)
-	if err != nil {
-		t.Fatalf("CurrentDeployedVersionID: %v", err)
-	}
-	if id != root.ID {
-		t.Fatalf("got %q, want %q", id, root.ID)
-	}
-}
-
-func TestAgentRepository_PartialUniqueIndex_RejectsDoubleDeploy(t *testing.T) {
-	_, db := withRepo(t)
-	ctx := context.Background()
-
-	rootID := uuid.NewString()
-	_, err := db.ExecContext(ctx,
-		`INSERT INTO agents (id, agent_id, name, status) VALUES ($1::uuid, $1::uuid, 'dbl-a', 'DEPLOYED')`,
-		rootID)
-	if err != nil {
-		t.Fatalf("first deploy insert: %v", err)
-	}
-	siblingID := uuid.NewString()
-	_, err = db.ExecContext(ctx,
-		`INSERT INTO agents (id, agent_id, name, status, parent_version_id) VALUES ($1::uuid, $2::uuid, 'dbl-a', 'DEPLOYED', $2::uuid)`,
-		siblingID, rootID)
-	if err == nil {
-		t.Fatalf("expected partial unique index violation, got nil error")
+	// Verify the rows exist
+	var count int
+	_ = db.QueryRowContext(ctx, `SELECT count(*) FROM agent_versions WHERE id=$1`, version.ID).Scan(&count)
+	if count != 1 {
+		t.Fatalf("expected agent_versions row, count=%d", count)
 	}
 }

--- a/open-bbcd/internal/repository/agent_test.go
+++ b/open-bbcd/internal/repository/agent_test.go
@@ -25,7 +25,7 @@ func TestAgentRepository_CreateFromWizard_ValidationError(t *testing.T) {
 }
 
 func TestAgentRepository_Create_ReturnsAgent(t *testing.T) {
-	repo, _ := withRepo(t)
+	repo, _, _ := withRepo(t)
 	ctx := context.Background()
 	a, err := repo.Create(ctx, types.CreateAgentOpts{Name: "create-test"})
 	if err != nil {
@@ -40,7 +40,7 @@ func TestAgentRepository_Create_ReturnsAgent(t *testing.T) {
 }
 
 func TestAgentRepository_CreateFromWizard_CreatesAgentAndVersion(t *testing.T) {
-	repo, db := withRepo(t)
+	repo, _, db := withRepo(t)
 	ctx := context.Background()
 	agent, version, err := repo.CreateFromWizard(ctx, types.CreateAgentFromWizardOpts{
 		Name: "wizard-test",

--- a/open-bbcd/internal/repository/agent_version.go
+++ b/open-bbcd/internal/repository/agent_version.go
@@ -1,0 +1,219 @@
+// open-bbcd/internal/repository/agent_version.go
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
+)
+
+type AgentVersionRepository struct {
+	db *sql.DB
+}
+
+func NewAgentVersionRepository(db *sql.DB) *AgentVersionRepository {
+	return &AgentVersionRepository{db: db}
+}
+
+const agentVersionColumns = `id, agent_id, parent_version_id, status, bundle, created_at, updated_at`
+
+func scanAgentVersion(s scanner) (*types.AgentVersion, error) {
+	v := &types.AgentVersion{}
+	var parent sql.NullString
+	var bundle []byte
+	if err := s.Scan(&v.ID, &v.AgentID, &parent, &v.Status, &bundle, &v.CreatedAt, &v.UpdatedAt); err != nil {
+		return nil, err
+	}
+	if parent.Valid {
+		v.ParentVersionID = &parent.String
+	}
+	v.Bundle = bundle
+	return v, nil
+}
+
+// GetByID returns the AgentVersion row by id.
+func (r *AgentVersionRepository) GetByID(ctx context.Context, versionID string) (*types.AgentVersion, error) {
+	row := r.db.QueryRowContext(ctx, `SELECT `+agentVersionColumns+` FROM agent_versions WHERE id = $1`, versionID)
+	v, err := scanAgentVersion(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, types.ErrNotFound
+	}
+	return v, err
+}
+
+// GetWithAgent returns both the AgentVersion and its owning Agent via JOIN.
+// Used by chat/configurator handlers that need both.
+func (r *AgentVersionRepository) GetWithAgent(ctx context.Context, versionID string) (*types.AgentVersion, *types.Agent, error) {
+	row := r.db.QueryRowContext(ctx, `
+		SELECT av.id::text, av.agent_id::text, av.parent_version_id, av.status, av.bundle, av.created_at, av.updated_at,
+		       a.id::text, a.name, a.description, a.flow_map_config, a.flow_map_parse_error, a.discovery_file_path, a.created_at
+		FROM agent_versions av
+		JOIN agents a ON a.id = av.agent_id
+		WHERE av.id = $1
+	`, versionID)
+	v := &types.AgentVersion{}
+	a := &types.Agent{}
+	var parent sql.NullString
+	var bundle []byte
+	var aDesc sql.NullString
+	var aCfg []byte
+	var aParseErr sql.NullString
+	var aDisc sql.NullString
+	err := row.Scan(&v.ID, &v.AgentID, &parent, &v.Status, &bundle, &v.CreatedAt, &v.UpdatedAt,
+		&a.ID, &a.Name, &aDesc, &aCfg, &aParseErr, &aDisc, &a.CreatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil, types.ErrNotFound
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	if parent.Valid {
+		v.ParentVersionID = &parent.String
+	}
+	v.Bundle = bundle
+	a.Description = aDesc.String
+	a.FlowMapConfig = aCfg
+	a.FlowMapParseError = aParseErr.String
+	a.DiscoveryFilePath = aDisc.String
+	return v, a, nil
+}
+
+// Deploy promotes versionID to DEPLOYED, demoting any other DEPLOYED version of
+// the same agent. Returns the previously-deployed version ID (or nil).
+func (r *AgentVersionRepository) Deploy(ctx context.Context, versionID string) (*string, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var status, agentID string
+	err = tx.QueryRowContext(ctx,
+		`SELECT status, agent_id::text FROM agent_versions WHERE id = $1`, versionID,
+	).Scan(&status, &agentID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, types.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if status == string(types.AgentStatusDeployed) {
+		if err := tx.Commit(); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+	if status != string(types.AgentStatusReady) {
+		return nil, types.ErrAgentNotDeployable
+	}
+	var prevID sql.NullString
+	err = tx.QueryRowContext(ctx, `
+		UPDATE agent_versions SET status = 'READY', updated_at = now()
+		WHERE agent_id = $1 AND status = 'DEPLOYED' AND id != $2
+		RETURNING id::text
+	`, agentID, versionID).Scan(&prevID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("demote previous: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE agent_versions SET status='DEPLOYED', updated_at = now() WHERE id = $1`, versionID,
+	); err != nil {
+		return nil, fmt.Errorf("promote target: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	if prevID.Valid {
+		return &prevID.String, nil
+	}
+	return nil, nil
+}
+
+// Undeploy demotes the version to READY.
+func (r *AgentVersionRepository) Undeploy(ctx context.Context, versionID string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE agent_versions SET status='READY', updated_at = now() WHERE id = $1 AND status = 'DEPLOYED'`,
+		versionID,
+	)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		var dummy string
+		err := r.db.QueryRowContext(ctx, `SELECT id::text FROM agent_versions WHERE id = $1`, versionID).Scan(&dummy)
+		if errors.Is(err, sql.ErrNoRows) {
+			return types.ErrNotFound
+		}
+		if err != nil {
+			return err
+		}
+		return types.ErrAgentNotDeployed
+	}
+	return nil
+}
+
+// CurrentDeployedID returns the version ID currently DEPLOYED for the given
+// agent, or "" if none.
+func (r *AgentVersionRepository) CurrentDeployedID(ctx context.Context, agentID string) (string, error) {
+	var id string
+	err := r.db.QueryRowContext(ctx,
+		`SELECT id::text FROM agent_versions WHERE agent_id = $1 AND status = 'DEPLOYED'`,
+		agentID,
+	).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// SetBundle persists the compiled bundle on a version row and transitions it to
+// READY. force=false rejects a non-NULL bundle to prevent accidental overwrites.
+func (r *AgentVersionRepository) SetBundle(ctx context.Context, versionID string, bundle []byte, force bool) error {
+	var q string
+	if force {
+		q = `UPDATE agent_versions SET bundle = $2::jsonb, status = 'READY', updated_at = now() WHERE id = $1`
+	} else {
+		q = `UPDATE agent_versions SET bundle = $2::jsonb, status = 'READY', updated_at = now() WHERE id = $1 AND bundle IS NULL`
+	}
+	res, err := r.db.ExecContext(ctx, q, versionID, bundle)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return types.ErrBundleAlreadySet
+	}
+	return nil
+}
+
+// UpdateStatus performs a guarded status transition on a version row.
+func (r *AgentVersionRepository) UpdateStatus(ctx context.Context, versionID, expectedFrom, to string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE agent_versions SET status = $3, updated_at = now() WHERE id = $1 AND status = $2`,
+		versionID, expectedFrom, to,
+	)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return types.ErrInvalidAgentStatus
+	}
+	return nil
+}

--- a/open-bbcd/internal/repository/agent_version.go
+++ b/open-bbcd/internal/repository/agent_version.go
@@ -18,19 +18,23 @@ func NewAgentVersionRepository(db *sql.DB) *AgentVersionRepository {
 	return &AgentVersionRepository{db: db}
 }
 
-const agentVersionColumns = `id, agent_id, parent_version_id, status, bundle, created_at, updated_at`
+const agentVersionColumns = `id, agent_id, parent_version_id, status, bundle, flow_map_config, flow_map_parse_error, created_at, updated_at`
 
 func scanAgentVersion(s scanner) (*types.AgentVersion, error) {
 	v := &types.AgentVersion{}
 	var parent sql.NullString
 	var bundle []byte
-	if err := s.Scan(&v.ID, &v.AgentID, &parent, &v.Status, &bundle, &v.CreatedAt, &v.UpdatedAt); err != nil {
+	var cfg []byte
+	var parseErr sql.NullString
+	if err := s.Scan(&v.ID, &v.AgentID, &parent, &v.Status, &bundle, &cfg, &parseErr, &v.CreatedAt, &v.UpdatedAt); err != nil {
 		return nil, err
 	}
 	if parent.Valid {
 		v.ParentVersionID = &parent.String
 	}
 	v.Bundle = bundle
+	v.FlowMapConfig = cfg
+	v.FlowMapParseError = parseErr.String
 	return v, nil
 }
 
@@ -48,8 +52,8 @@ func (r *AgentVersionRepository) GetByID(ctx context.Context, versionID string) 
 // Used by chat/configurator handlers that need both.
 func (r *AgentVersionRepository) GetWithAgent(ctx context.Context, versionID string) (*types.AgentVersion, *types.Agent, error) {
 	row := r.db.QueryRowContext(ctx, `
-		SELECT av.id::text, av.agent_id::text, av.parent_version_id, av.status, av.bundle, av.created_at, av.updated_at,
-		       a.id::text, a.name, a.description, a.flow_map_config, a.flow_map_parse_error, a.discovery_file_path, a.created_at
+		SELECT av.id::text, av.agent_id::text, av.parent_version_id, av.status, av.bundle, av.flow_map_config, av.flow_map_parse_error, av.created_at, av.updated_at,
+		       a.id::text, a.name, a.description, a.discovery_file_path, a.created_at
 		FROM agent_versions av
 		JOIN agents a ON a.id = av.agent_id
 		WHERE av.id = $1
@@ -58,12 +62,12 @@ func (r *AgentVersionRepository) GetWithAgent(ctx context.Context, versionID str
 	a := &types.Agent{}
 	var parent sql.NullString
 	var bundle []byte
+	var vCfg []byte
+	var vParseErr sql.NullString
 	var aDesc sql.NullString
-	var aCfg []byte
-	var aParseErr sql.NullString
 	var aDisc sql.NullString
-	err := row.Scan(&v.ID, &v.AgentID, &parent, &v.Status, &bundle, &v.CreatedAt, &v.UpdatedAt,
-		&a.ID, &a.Name, &aDesc, &aCfg, &aParseErr, &aDisc, &a.CreatedAt)
+	err := row.Scan(&v.ID, &v.AgentID, &parent, &v.Status, &bundle, &vCfg, &vParseErr, &v.CreatedAt, &v.UpdatedAt,
+		&a.ID, &a.Name, &aDesc, &aDisc, &a.CreatedAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil, types.ErrNotFound
 	}
@@ -74,9 +78,9 @@ func (r *AgentVersionRepository) GetWithAgent(ctx context.Context, versionID str
 		v.ParentVersionID = &parent.String
 	}
 	v.Bundle = bundle
+	v.FlowMapConfig = vCfg
+	v.FlowMapParseError = vParseErr.String
 	a.Description = aDesc.String
-	a.FlowMapConfig = aCfg
-	a.FlowMapParseError = aParseErr.String
 	a.DiscoveryFilePath = aDisc.String
 	return v, a, nil
 }
@@ -214,6 +218,45 @@ func (r *AgentVersionRepository) UpdateStatus(ctx context.Context, versionID, ex
 	}
 	if n == 0 {
 		return types.ErrInvalidAgentStatus
+	}
+	return nil
+}
+
+// GetFlowMapConfig returns the version's flow_map_config + parse_error.
+// Returns ErrNotFound if the version does not exist.
+func (r *AgentVersionRepository) GetFlowMapConfig(ctx context.Context, versionID string) ([]byte, string, error) {
+	var cfg []byte
+	var parseErr sql.NullString
+	err := r.db.QueryRowContext(ctx,
+		`SELECT flow_map_config, flow_map_parse_error FROM agent_versions WHERE id = $1`,
+		versionID,
+	).Scan(&cfg, &parseErr)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, "", types.ErrNotFound
+	}
+	if err != nil {
+		return nil, "", err
+	}
+	return cfg, parseErr.String, nil
+}
+
+// UpdateFlowMapConfig overwrites this version's config in place. (Future:
+// when the FE enables edits, this should spawn a new version. Out of scope
+// for now.)
+func (r *AgentVersionRepository) UpdateFlowMapConfig(ctx context.Context, versionID string, cfg []byte) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE agent_versions SET flow_map_config = $2, flow_map_parse_error = NULL, updated_at = now() WHERE id = $1`,
+		versionID, cfg,
+	)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return types.ErrNotFound
 	}
 	return nil
 }

--- a/open-bbcd/internal/repository/agent_version_test.go
+++ b/open-bbcd/internal/repository/agent_version_test.go
@@ -1,0 +1,209 @@
+// open-bbcd/internal/repository/agent_version_test.go
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
+	"github.com/google/uuid"
+)
+
+// seedReadyAgentVersion creates an agent + a READY version with a dummy bundle.
+// Returns (agentID, versionID).
+func seedReadyAgentVersion(t *testing.T) (string, string) {
+	t.Helper()
+	agentRepo, _, db := withRepo(t)
+	ctx := context.Background()
+	agent, version, err := agentRepo.CreateFromWizard(ctx, types.CreateAgentFromWizardOpts{
+		Name: "av-" + uuid.NewString()[:8],
+	})
+	if err != nil {
+		t.Fatalf("CreateFromWizard: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`UPDATE agent_versions SET status='READY', bundle='{}'::jsonb WHERE id=$1`, version.ID,
+	); err != nil {
+		t.Fatalf("seed READY: %v", err)
+	}
+	return agent.ID, version.ID
+}
+
+// insertReadyChildVersion inserts a READY child version under parentID.
+func insertReadyChildVersion(t *testing.T, db *sql.DB, parentID string) string {
+	t.Helper()
+	var agentID string
+	if err := db.QueryRow(`SELECT agent_id::text FROM agent_versions WHERE id=$1`, parentID).Scan(&agentID); err != nil {
+		t.Fatalf("lookup agent: %v", err)
+	}
+	id := uuid.NewString()
+	if _, err := db.Exec(`
+		INSERT INTO agent_versions (id, agent_id, parent_version_id, status, bundle)
+		VALUES ($1::uuid, $2::uuid, $3::uuid, 'READY', '{}'::jsonb)
+	`, id, agentID, parentID); err != nil {
+		t.Fatalf("insert child: %v", err)
+	}
+	return id
+}
+
+func TestAgentVersionRepository_GetByID(t *testing.T) {
+	_, versionID := seedReadyAgentVersion(t)
+	_, versionRepo, _ := withRepo(t)
+	v, err := versionRepo.GetByID(context.Background(), versionID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if v.ID != versionID {
+		t.Fatalf("ID mismatch")
+	}
+	if v.Status != "READY" {
+		t.Fatalf("status=%q", v.Status)
+	}
+}
+
+func TestAgentVersionRepository_GetWithAgent(t *testing.T) {
+	agentID, versionID := seedReadyAgentVersion(t)
+	_, versionRepo, _ := withRepo(t)
+	v, a, err := versionRepo.GetWithAgent(context.Background(), versionID)
+	if err != nil {
+		t.Fatalf("GetWithAgent: %v", err)
+	}
+	if v.AgentID != agentID || a.ID != agentID {
+		t.Fatalf("mismatch v=%q a=%q want %q", v.AgentID, a.ID, agentID)
+	}
+}
+
+func TestAgentVersionRepository_Deploy_HappyPath(t *testing.T) {
+	_, versionID := seedReadyAgentVersion(t)
+	_, versionRepo, _ := withRepo(t)
+	ctx := context.Background()
+	prev, err := versionRepo.Deploy(ctx, versionID)
+	if err != nil {
+		t.Fatalf("Deploy: %v", err)
+	}
+	if prev != nil {
+		t.Fatalf("prev should be nil, got %q", *prev)
+	}
+	v, _ := versionRepo.GetByID(ctx, versionID)
+	if v.Status != "DEPLOYED" {
+		t.Fatalf("status=%q", v.Status)
+	}
+}
+
+func TestAgentVersionRepository_Deploy_Rotates(t *testing.T) {
+	_, versionID := seedReadyAgentVersion(t)
+	_, versionRepo, db := withRepo(t)
+	ctx := context.Background()
+	_, _ = versionRepo.Deploy(ctx, versionID)
+	child := insertReadyChildVersion(t, db, versionID)
+	prev, err := versionRepo.Deploy(ctx, child)
+	if err != nil {
+		t.Fatalf("Deploy child: %v", err)
+	}
+	if prev == nil || *prev != versionID {
+		t.Fatalf("prev=%v want %q", prev, versionID)
+	}
+	rootAfter, _ := versionRepo.GetByID(ctx, versionID)
+	childAfter, _ := versionRepo.GetByID(ctx, child)
+	if rootAfter.Status != "READY" {
+		t.Fatalf("root status=%q", rootAfter.Status)
+	}
+	if childAfter.Status != "DEPLOYED" {
+		t.Fatalf("child status=%q", childAfter.Status)
+	}
+}
+
+func TestAgentVersionRepository_Deploy_NotDeployable(t *testing.T) {
+	// Create an agent + INITIALIZING version (Status not READY).
+	agentRepo, versionRepo, _ := withRepo(t)
+	ctx := context.Background()
+	_, version, err := agentRepo.CreateFromWizard(ctx, types.CreateAgentFromWizardOpts{Name: "nd-" + uuid.NewString()[:8]})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, err = versionRepo.Deploy(ctx, version.ID)
+	if !errors.Is(err, types.ErrAgentNotDeployable) {
+		t.Fatalf("got %v want ErrAgentNotDeployable", err)
+	}
+}
+
+func TestAgentVersionRepository_Deploy_Idempotent(t *testing.T) {
+	_, versionID := seedReadyAgentVersion(t)
+	_, versionRepo, _ := withRepo(t)
+	ctx := context.Background()
+	_, _ = versionRepo.Deploy(ctx, versionID)
+	prev, err := versionRepo.Deploy(ctx, versionID)
+	if err != nil {
+		t.Fatalf("re-Deploy: %v", err)
+	}
+	if prev != nil {
+		t.Fatalf("prev should be nil, got %q", *prev)
+	}
+	v, _ := versionRepo.GetByID(ctx, versionID)
+	if v.Status != "DEPLOYED" {
+		t.Fatalf("status=%q", v.Status)
+	}
+}
+
+func TestAgentVersionRepository_Undeploy(t *testing.T) {
+	_, versionID := seedReadyAgentVersion(t)
+	_, versionRepo, _ := withRepo(t)
+	ctx := context.Background()
+	_, _ = versionRepo.Deploy(ctx, versionID)
+	if err := versionRepo.Undeploy(ctx, versionID); err != nil {
+		t.Fatalf("Undeploy: %v", err)
+	}
+	v, _ := versionRepo.GetByID(ctx, versionID)
+	if v.Status != "READY" {
+		t.Fatalf("status=%q", v.Status)
+	}
+	if err := versionRepo.Undeploy(ctx, versionID); !errors.Is(err, types.ErrAgentNotDeployed) {
+		t.Fatalf("re-Undeploy: got %v want ErrAgentNotDeployed", err)
+	}
+}
+
+func TestAgentVersionRepository_CurrentDeployedID(t *testing.T) {
+	agentID, versionID := seedReadyAgentVersion(t)
+	_, versionRepo, _ := withRepo(t)
+	ctx := context.Background()
+	id, err := versionRepo.CurrentDeployedID(ctx, agentID)
+	if err != nil {
+		t.Fatalf("CurrentDeployedID empty: %v", err)
+	}
+	if id != "" {
+		t.Fatalf("empty expected, got %q", id)
+	}
+	_, _ = versionRepo.Deploy(ctx, versionID)
+	id, _ = versionRepo.CurrentDeployedID(ctx, agentID)
+	if id != versionID {
+		t.Fatalf("got %q want %q", id, versionID)
+	}
+}
+
+func TestAgentVersionRepository_PartialUniqueIndex_RejectsDoubleDeploy(t *testing.T) {
+	_, _, db := withRepo(t)
+	ctx := context.Background()
+	agentID := uuid.NewString()
+	_, err := db.ExecContext(ctx, `INSERT INTO agents (id, name) VALUES ($1::uuid, $2)`, agentID, "dbl-test")
+	if err != nil {
+		t.Fatalf("agent insert: %v", err)
+	}
+	id1 := uuid.NewString()
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agent_versions (id, agent_id, status, bundle) VALUES ($1::uuid, $2::uuid, 'DEPLOYED', '{}'::jsonb)`,
+		id1, agentID,
+	)
+	if err != nil {
+		t.Fatalf("first deploy insert: %v", err)
+	}
+	id2 := uuid.NewString()
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO agent_versions (id, agent_id, parent_version_id, status, bundle) VALUES ($1::uuid, $2::uuid, $3::uuid, 'DEPLOYED', '{}'::jsonb)`,
+		id2, agentID, id1,
+	)
+	if err == nil {
+		t.Fatalf("expected partial unique index violation")
+	}
+}

--- a/open-bbcd/internal/repository/agent_version_test.go
+++ b/open-bbcd/internal/repository/agent_version_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 // seedReadyAgentVersion creates an agent + a READY version with a dummy bundle.
-// Returns (agentID, versionID).
-func seedReadyAgentVersion(t *testing.T) (string, string) {
+// Returns (agentID, versionID) plus the repos and db handle from withRepo.
+// Callers MUST reuse these returns instead of calling withRepo again (which
+// would truncate the just-seeded rows).
+func seedReadyAgentVersion(t *testing.T) (agentID, versionID string, agentRepo *AgentRepository, versionRepo *AgentVersionRepository, db *sql.DB) {
 	t.Helper()
-	agentRepo, _, db := withRepo(t)
+	agentRepo, versionRepo, db = withRepo(t)
 	ctx := context.Background()
 	agent, version, err := agentRepo.CreateFromWizard(ctx, types.CreateAgentFromWizardOpts{
 		Name: "av-" + uuid.NewString()[:8],
@@ -28,7 +30,7 @@ func seedReadyAgentVersion(t *testing.T) (string, string) {
 	); err != nil {
 		t.Fatalf("seed READY: %v", err)
 	}
-	return agent.ID, version.ID
+	return agent.ID, version.ID, agentRepo, versionRepo, db
 }
 
 // insertReadyChildVersion inserts a READY child version under parentID.
@@ -49,8 +51,7 @@ func insertReadyChildVersion(t *testing.T, db *sql.DB, parentID string) string {
 }
 
 func TestAgentVersionRepository_GetByID(t *testing.T) {
-	_, versionID := seedReadyAgentVersion(t)
-	_, versionRepo, _ := withRepo(t)
+	_, versionID, _, versionRepo, _ := seedReadyAgentVersion(t)
 	v, err := versionRepo.GetByID(context.Background(), versionID)
 	if err != nil {
 		t.Fatalf("GetByID: %v", err)
@@ -64,8 +65,7 @@ func TestAgentVersionRepository_GetByID(t *testing.T) {
 }
 
 func TestAgentVersionRepository_GetWithAgent(t *testing.T) {
-	agentID, versionID := seedReadyAgentVersion(t)
-	_, versionRepo, _ := withRepo(t)
+	agentID, versionID, _, versionRepo, _ := seedReadyAgentVersion(t)
 	v, a, err := versionRepo.GetWithAgent(context.Background(), versionID)
 	if err != nil {
 		t.Fatalf("GetWithAgent: %v", err)
@@ -76,8 +76,7 @@ func TestAgentVersionRepository_GetWithAgent(t *testing.T) {
 }
 
 func TestAgentVersionRepository_Deploy_HappyPath(t *testing.T) {
-	_, versionID := seedReadyAgentVersion(t)
-	_, versionRepo, _ := withRepo(t)
+	_, versionID, _, versionRepo, _ := seedReadyAgentVersion(t)
 	ctx := context.Background()
 	prev, err := versionRepo.Deploy(ctx, versionID)
 	if err != nil {
@@ -93,8 +92,7 @@ func TestAgentVersionRepository_Deploy_HappyPath(t *testing.T) {
 }
 
 func TestAgentVersionRepository_Deploy_Rotates(t *testing.T) {
-	_, versionID := seedReadyAgentVersion(t)
-	_, versionRepo, db := withRepo(t)
+	_, versionID, _, versionRepo, db := seedReadyAgentVersion(t)
 	ctx := context.Background()
 	_, _ = versionRepo.Deploy(ctx, versionID)
 	child := insertReadyChildVersion(t, db, versionID)
@@ -130,8 +128,7 @@ func TestAgentVersionRepository_Deploy_NotDeployable(t *testing.T) {
 }
 
 func TestAgentVersionRepository_Deploy_Idempotent(t *testing.T) {
-	_, versionID := seedReadyAgentVersion(t)
-	_, versionRepo, _ := withRepo(t)
+	_, versionID, _, versionRepo, _ := seedReadyAgentVersion(t)
 	ctx := context.Background()
 	_, _ = versionRepo.Deploy(ctx, versionID)
 	prev, err := versionRepo.Deploy(ctx, versionID)
@@ -148,8 +145,7 @@ func TestAgentVersionRepository_Deploy_Idempotent(t *testing.T) {
 }
 
 func TestAgentVersionRepository_Undeploy(t *testing.T) {
-	_, versionID := seedReadyAgentVersion(t)
-	_, versionRepo, _ := withRepo(t)
+	_, versionID, _, versionRepo, _ := seedReadyAgentVersion(t)
 	ctx := context.Background()
 	_, _ = versionRepo.Deploy(ctx, versionID)
 	if err := versionRepo.Undeploy(ctx, versionID); err != nil {
@@ -165,8 +161,7 @@ func TestAgentVersionRepository_Undeploy(t *testing.T) {
 }
 
 func TestAgentVersionRepository_CurrentDeployedID(t *testing.T) {
-	agentID, versionID := seedReadyAgentVersion(t)
-	_, versionRepo, _ := withRepo(t)
+	agentID, versionID, _, versionRepo, _ := seedReadyAgentVersion(t)
 	ctx := context.Background()
 	id, err := versionRepo.CurrentDeployedID(ctx, agentID)
 	if err != nil {

--- a/open-bbcd/internal/repository/chat.go
+++ b/open-bbcd/internal/repository/chat.go
@@ -17,54 +17,54 @@ func NewChatRepository(db *sql.DB) *ChatRepository {
 }
 
 // EnsureSession inserts a chat_sessions row with the given id if it
-// doesn't already exist. If the row exists with a different agent_id,
+// doesn't already exist. If the row exists with a different agent_version_id,
 // returns ErrSessionAgentMismatch. Idempotent: calling twice with the
-// same (sessionID, agentID) is a no-op.
+// same (sessionID, versionID) is a no-op.
 //
 // The ON CONFLICT … DO UPDATE SET id = chat_sessions.id is a deliberate
 // no-op update that lets RETURNING fire on conflict — without it,
 // detecting mismatch would require a second round-trip.
-func (r *ChatRepository) EnsureSession(ctx context.Context, sessionID, agentID string) error {
-	var existingAgentID string
+func (r *ChatRepository) EnsureSession(ctx context.Context, sessionID, versionID string) error {
+	var existingVersionID string
 	err := r.db.QueryRowContext(ctx, `
-		INSERT INTO chat_sessions (id, agent_id) VALUES ($1::uuid, $2::uuid)
+		INSERT INTO chat_sessions (id, agent_version_id) VALUES ($1::uuid, $2::uuid)
 		ON CONFLICT (id) DO UPDATE SET id = chat_sessions.id
-		RETURNING agent_id::text
-	`, sessionID, agentID).Scan(&existingAgentID)
+		RETURNING agent_version_id::text
+	`, sessionID, versionID).Scan(&existingVersionID)
 	if err != nil {
 		return err
 	}
-	if existingAgentID != agentID {
+	if existingVersionID != versionID {
 		return types.ErrSessionAgentMismatch
 	}
 	return nil
 }
 
-// GetSession loads a single session and verifies it belongs to agentID.
+// GetSession loads a single session and verifies it belongs to versionID.
 // Returns ErrNotFound if the session doesn't exist and ErrSessionAgentMismatch
-// if it exists but is owned by a different agent.
-func (r *ChatRepository) GetSession(ctx context.Context, sessionID, agentID string) (*types.ChatSession, error) {
+// if it exists but is owned by a different agent version.
+func (r *ChatRepository) GetSession(ctx context.Context, sessionID, versionID string) (*types.ChatSession, error) {
 	s := &types.ChatSession{}
 	err := r.db.QueryRowContext(ctx, `
-		SELECT id::text, agent_id::text, COALESCE(title, ''), created_at, updated_at
+		SELECT id::text, agent_version_id::text, COALESCE(title, ''), created_at, updated_at
 		FROM chat_sessions
 		WHERE id = $1::uuid
-	`, sessionID).Scan(&s.ID, &s.AgentID, &s.Title, &s.CreatedAt, &s.UpdatedAt)
+	`, sessionID).Scan(&s.ID, &s.AgentVersionID, &s.Title, &s.CreatedAt, &s.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, types.ErrNotFound
 		}
 		return nil, err
 	}
-	if s.AgentID != agentID {
+	if s.AgentVersionID != versionID {
 		return nil, types.ErrSessionAgentMismatch
 	}
 	return s, nil
 }
 
 // UpdateSessionTitle sets the title of a session. Verifies the session belongs
-// to agentID before updating. An empty title clears the column (NULL in DB).
-func (r *ChatRepository) UpdateSessionTitle(ctx context.Context, sessionID, agentID, title string) error {
+// to versionID before updating. An empty title clears the column (NULL in DB).
+func (r *ChatRepository) UpdateSessionTitle(ctx context.Context, sessionID, versionID, title string) error {
 	var nullable sql.NullString
 	if title != "" {
 		nullable = sql.NullString{String: title, Valid: true}
@@ -72,8 +72,8 @@ func (r *ChatRepository) UpdateSessionTitle(ctx context.Context, sessionID, agen
 	res, err := r.db.ExecContext(ctx, `
 		UPDATE chat_sessions
 		SET title = $3, updated_at = now()
-		WHERE id = $1::uuid AND agent_id = $2::uuid
-	`, sessionID, agentID, nullable)
+		WHERE id = $1::uuid AND agent_version_id = $2::uuid
+	`, sessionID, versionID, nullable)
 	if err != nil {
 		return err
 	}
@@ -82,13 +82,13 @@ func (r *ChatRepository) UpdateSessionTitle(ctx context.Context, sessionID, agen
 		return err
 	}
 	if n == 0 {
-		// Either the session doesn't exist or it belongs to another agent.
+		// Either the session doesn't exist or it belongs to another agent version.
 		// Distinguish for the caller.
-		var existingAgent string
+		var existingVersion string
 		err := r.db.QueryRowContext(ctx,
-			`SELECT agent_id::text FROM chat_sessions WHERE id = $1::uuid`,
+			`SELECT agent_version_id::text FROM chat_sessions WHERE id = $1::uuid`,
 			sessionID,
-		).Scan(&existingAgent)
+		).Scan(&existingVersion)
 		if errors.Is(err, sql.ErrNoRows) {
 			return types.ErrNotFound
 		}
@@ -100,14 +100,14 @@ func (r *ChatRepository) UpdateSessionTitle(ctx context.Context, sessionID, agen
 	return nil
 }
 
-// ListSessions returns all sessions for an agent, newest first.
-func (r *ChatRepository) ListSessions(ctx context.Context, agentID string) ([]*types.ChatSession, error) {
+// ListSessions returns all sessions for an agent version, newest first.
+func (r *ChatRepository) ListSessions(ctx context.Context, versionID string) ([]*types.ChatSession, error) {
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id::text, agent_id::text, COALESCE(title, ''), created_at, updated_at
+		SELECT id::text, agent_version_id::text, COALESCE(title, ''), created_at, updated_at
 		FROM chat_sessions
-		WHERE agent_id = $1::uuid
+		WHERE agent_version_id = $1::uuid
 		ORDER BY created_at DESC
-	`, agentID)
+	`, versionID)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (r *ChatRepository) ListSessions(ctx context.Context, agentID string) ([]*t
 	var out []*types.ChatSession
 	for rows.Next() {
 		s := &types.ChatSession{}
-		if err := rows.Scan(&s.ID, &s.AgentID, &s.Title, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		if err := rows.Scan(&s.ID, &s.AgentVersionID, &s.Title, &s.CreatedAt, &s.UpdatedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, s)
@@ -156,8 +156,8 @@ func (r *ChatRepository) LoadMessages(ctx context.Context, sessionID string) ([]
 // Also bumps the session's updated_at.
 //
 // agentVersionID is accepted for interface conformance with the deployed-store
-// sibling; BO chat sessions are already version-pinned via chat_sessions.agent_id,
-// so this parameter is ignored here.
+// sibling; BO chat sessions are already version-pinned via
+// chat_sessions.agent_version_id, so this parameter is ignored here.
 func (r *ChatRepository) AppendMessages(ctx context.Context, agentVersionID string, msgs []types.ChatMessage) error {
 	_ = agentVersionID
 	if len(msgs) == 0 {

--- a/open-bbcd/internal/repository/deployed_test.go
+++ b/open-bbcd/internal/repository/deployed_test.go
@@ -10,18 +10,25 @@ import (
 	"github.com/google/uuid"
 )
 
-func newDeployedRepoTest(t *testing.T) (*DeployedRepository, *AgentRepository, string) {
+func newDeployedRepoTest(t *testing.T) (*DeployedRepository, *AgentVersionRepository, string) {
 	t.Helper()
-	agentRepo, db := withRepo(t)
+	agentRepo, versionRepo, db := withRepo(t)
 	ctx := context.Background()
-	root, _ := agentRepo.Create(ctx, types.CreateAgentOpts{Name: "depl-" + uuid.NewString()[:8]})
-	if _, err := db.ExecContext(ctx, `UPDATE agents SET status='READY' WHERE id=$1`, root.ID); err != nil {
+	agent, version, err := agentRepo.CreateFromWizard(ctx, types.CreateAgentFromWizardOpts{
+		Name: "depl-" + uuid.NewString()[:8],
+	})
+	if err != nil {
+		t.Fatalf("CreateFromWizard: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`UPDATE agent_versions SET status='READY', bundle='{}'::jsonb WHERE id=$1`, version.ID,
+	); err != nil {
 		t.Fatalf("seed READY: %v", err)
 	}
-	if _, err := agentRepo.Deploy(ctx, root.ID); err != nil {
+	if _, err := versionRepo.Deploy(ctx, version.ID); err != nil {
 		t.Fatalf("Deploy: %v", err)
 	}
-	return NewDeployedRepository(db), agentRepo, root.ID
+	return NewDeployedRepository(db), versionRepo, agent.ID
 }
 
 func TestDeployedRepository_CreateAndGetSession(t *testing.T) {
@@ -74,10 +81,10 @@ func TestDeployedRepository_ListSessions_ScopedByUser(t *testing.T) {
 }
 
 func TestDeployedRepository_AppendMessages_StampsVersion(t *testing.T) {
-	repo, agentRepo, chainRoot := newDeployedRepoTest(t)
+	repo, versionRepo, chainRoot := newDeployedRepoTest(t)
 	ctx := context.Background()
 
-	versionID, _ := agentRepo.CurrentDeployedVersionID(ctx, chainRoot)
+	versionID, _ := versionRepo.CurrentDeployedID(ctx, chainRoot)
 	sess, _ := repo.CreateSession(ctx, chainRoot, "user-A", "")
 
 	err := repo.AppendMessages(ctx, []types.DeployedMessage{
@@ -103,9 +110,9 @@ func TestDeployedRepository_AppendMessages_StampsVersion(t *testing.T) {
 }
 
 func TestDeployedRepository_DeleteSession_CascadesMessages(t *testing.T) {
-	repo, agentRepo, chainRoot := newDeployedRepoTest(t)
+	repo, versionRepo, chainRoot := newDeployedRepoTest(t)
 	ctx := context.Background()
-	versionID, _ := agentRepo.CurrentDeployedVersionID(ctx, chainRoot)
+	versionID, _ := versionRepo.CurrentDeployedID(ctx, chainRoot)
 	sess, _ := repo.CreateSession(ctx, chainRoot, "user-A", "")
 	_ = repo.AppendMessages(ctx, []types.DeployedMessage{
 		{SessionID: sess.ID, AgentVersionID: versionID, Role: types.ChatRoleUser,

--- a/open-bbcd/internal/repository/integration_helper_test.go
+++ b/open-bbcd/internal/repository/integration_helper_test.go
@@ -36,7 +36,7 @@ func withRepo(t *testing.T) (*AgentRepository, *sql.DB) {
 
 	// Truncate in dependency order. agents is parent for many other tables;
 	// CASCADE handles the rest. Tables created in migration 011 are included.
-	if _, err := db.Exec(`TRUNCATE deployed_messages, deployed_sessions, chat_messages, chat_sessions, resources, agents RESTART IDENTITY CASCADE`); err != nil {
+	if _, err := db.Exec(`TRUNCATE deployed_messages, deployed_sessions, chat_messages, chat_sessions, resources, agent_versions, agents RESTART IDENTITY CASCADE`); err != nil {
 		t.Fatalf("truncate: %v", err)
 	}
 	return NewAgentRepository(db), db

--- a/open-bbcd/internal/repository/integration_helper_test.go
+++ b/open-bbcd/internal/repository/integration_helper_test.go
@@ -19,7 +19,7 @@ import (
 // Each call hands back a fresh schema-scoped tablespace by truncating the
 // tables it touches at the start of the test — minimizing cross-test
 // interference without dropping migrations.
-func withRepo(t *testing.T) (*AgentRepository, *sql.DB) {
+func withRepo(t *testing.T) (*AgentRepository, *AgentVersionRepository, *sql.DB) {
 	t.Helper()
 	dsn := os.Getenv("DATABASE_URL")
 	if dsn == "" {
@@ -39,5 +39,5 @@ func withRepo(t *testing.T) (*AgentRepository, *sql.DB) {
 	if _, err := db.Exec(`TRUNCATE deployed_messages, deployed_sessions, chat_messages, chat_sessions, resources, agent_versions, agents RESTART IDENTITY CASCADE`); err != nil {
 		t.Fatalf("truncate: %v", err)
 	}
-	return NewAgentRepository(db), db
+	return NewAgentRepository(db), NewAgentVersionRepository(db), db
 }

--- a/open-bbcd/internal/repository/scanner.go
+++ b/open-bbcd/internal/repository/scanner.go
@@ -1,0 +1,8 @@
+// open-bbcd/internal/repository/scanner.go
+package repository
+
+// scanner is the common subset of *sql.Row and *sql.Rows that the repo
+// scan helpers depend on.
+type scanner interface {
+	Scan(dest ...any) error
+}

--- a/open-bbcd/internal/types/agent.go
+++ b/open-bbcd/internal/types/agent.go
@@ -17,29 +17,32 @@ const (
 	AgentStatusDeployed     AgentStatus = "DEPLOYED"
 )
 
-// Agent is one logical agent (the integrator's stable identity). The flow-map
-// source, name, and description live here; per-version state (bundle, status,
+// Agent is one logical agent (the integrator's stable identity). Only the
+// name, description, and discovery-file pointer live here — everything that
+// changes per regeneration (flow-map source, parse error, status, bundle,
 // parent pointer) lives on AgentVersion.
 type Agent struct {
-	ID                string          `json:"id"`
-	Name              string          `json:"name"`
-	Description       string          `json:"description,omitempty"`
-	FlowMapConfig     json.RawMessage `json:"flow_map_config,omitempty"`
-	FlowMapParseError string          `json:"flow_map_parse_error,omitempty"`
-	DiscoveryFilePath string          `json:"discovery_file_path,omitempty"`
-	CreatedAt         time.Time       `json:"created_at"`
+	ID                string    `json:"id"`
+	Name              string    `json:"name"`
+	Description       string    `json:"description,omitempty"`
+	DiscoveryFilePath string    `json:"discovery_file_path,omitempty"`
+	CreatedAt         time.Time `json:"created_at"`
 }
 
-// AgentVersion is one version row. It carries lifecycle (status), the compiled
-// bundle, and the linked-list parent pointer. Per-agent metadata is on Agent.
+// AgentVersion is one version row. It carries lifecycle (status), the flow-map
+// source the version was generated from (FlowMapConfig + FlowMapParseError),
+// the compiled bundle, and the linked-list parent pointer. Per-agent metadata
+// (name, description, discovery file path) is on Agent.
 type AgentVersion struct {
-	ID              string          `json:"id"`
-	AgentID         string          `json:"agent_id"`
-	ParentVersionID *string         `json:"parent_version_id,omitempty"`
-	Status          string          `json:"status"`
-	Bundle          json.RawMessage `json:"bundle,omitempty"`
-	CreatedAt       time.Time       `json:"created_at"`
-	UpdatedAt       time.Time       `json:"updated_at"`
+	ID                string          `json:"id"`
+	AgentID           string          `json:"agent_id"`
+	ParentVersionID   *string         `json:"parent_version_id,omitempty"`
+	Status            string          `json:"status"`
+	Bundle            json.RawMessage `json:"bundle,omitempty"`
+	FlowMapConfig     json.RawMessage `json:"flow_map_config,omitempty"`
+	FlowMapParseError string          `json:"flow_map_parse_error,omitempty"`
+	CreatedAt         time.Time       `json:"created_at"`
+	UpdatedAt         time.Time       `json:"updated_at"`
 }
 
 // AgentVersionListItem is an AgentVersion plus its 1-based positional number
@@ -65,13 +68,16 @@ type CreateAgentOpts struct {
 
 // CreateAgentFromWizardOpts is the input for AgentRepository.CreateFromWizard
 // (wizard path). The repository creates the agents row + the initial INITIALIZING
-// AgentVersion row in a single transaction.
+// AgentVersion row in a single transaction. The fields split across the two
+// rows as follows:
+//   - ID, Name, DiscoveryFilePath  → agents row
+//   - FlowMapConfig, FlowMapParseError → first agent_versions row
 type CreateAgentFromWizardOpts struct {
-	ID                string          // optional pre-generated agent id
-	Name              string
-	FlowMapConfig     json.RawMessage // pre-marshaled JSONB; nil if parse failed
-	FlowMapParseError string
-	DiscoveryFilePath string
+	ID                string          // optional pre-generated agent id (agents row)
+	Name              string          // agents row
+	FlowMapConfig     json.RawMessage // first agent_versions row; pre-marshaled JSONB, nil if parse failed
+	FlowMapParseError string          // first agent_versions row
+	DiscoveryFilePath string          // agents row
 }
 
 func NewAgent(opts CreateAgentOpts) (*Agent, error) {

--- a/open-bbcd/internal/types/agent.go
+++ b/open-bbcd/internal/types/agent.go
@@ -8,9 +8,7 @@ import (
 
 type AgentStatus string
 
-// Lifecycle: INITIALIZING (wizard) -> DRAFT (finalized config) ->
-// TRAINING (aikdm generating/iterating) -> READY (bundle finalized for this
-// version) -> DEPLOYED.
+// Lifecycle is the same as before — it lives on AgentVersion now.
 const (
 	AgentStatusInitializing AgentStatus = "INITIALIZING"
 	AgentStatusDraft        AgentStatus = "DRAFT"
@@ -19,46 +17,60 @@ const (
 	AgentStatusDeployed     AgentStatus = "DEPLOYED"
 )
 
+// Agent is one logical agent (the integrator's stable identity). The flow-map
+// source, name, and description live here; per-version state (bundle, status,
+// parent pointer) lives on AgentVersion.
 type Agent struct {
 	ID                string          `json:"id"`
-	AgentID       string          `json:"agent_id"`
 	Name              string          `json:"name"`
 	Description       string          `json:"description,omitempty"`
-	Bundle            json.RawMessage `json:"bundle,omitempty"`
-	Status            string          `json:"status"`
-	ParentVersionID   *string         `json:"parent_version_id,omitempty"`
 	FlowMapConfig     json.RawMessage `json:"flow_map_config,omitempty"`
 	FlowMapParseError string          `json:"flow_map_parse_error,omitempty"`
 	DiscoveryFilePath string          `json:"discovery_file_path,omitempty"`
 	CreatedAt         time.Time       `json:"created_at"`
-	UpdatedAt         time.Time       `json:"updated_at"`
 }
 
-// AgentVersion pairs an Agent with its computed version number within a chain.
+// AgentVersion is one version row. It carries lifecycle (status), the compiled
+// bundle, and the linked-list parent pointer. Per-agent metadata is on Agent.
 type AgentVersion struct {
-	Agent      *Agent
-	VersionNum int
+	ID              string          `json:"id"`
+	AgentID         string          `json:"agent_id"`
+	ParentVersionID *string         `json:"parent_version_id,omitempty"`
+	Status          string          `json:"status"`
+	Bundle          json.RawMessage `json:"bundle,omitempty"`
+	CreatedAt       time.Time       `json:"created_at"`
+	UpdatedAt       time.Time       `json:"updated_at"`
 }
 
-// AgentGroup groups all version rows that share the same logical agent.
-// AgentID is the stable identifier the integrator pastes into clients; it is
-// the ID of the oldest version row (the only one with parent_version_id NULL).
+// AgentVersionListItem is an AgentVersion plus its 1-based positional number
+// within an agent's version history. Used by AgentGroup for UI listings.
+type AgentVersionListItem struct {
+	Version    *AgentVersion `json:"version"`
+	VersionNum int           `json:"version_num"`
+}
+
+// AgentGroup groups all versions of a single agent. AgentID is the stable
+// identifier; Name is the agent's name (copied from Agent for template convenience).
 type AgentGroup struct {
-	AgentID  string
-	Name     string
-	Versions []AgentVersion
+	AgentID  string                 `json:"agent_id"`
+	Name     string                 `json:"name"`
+	Versions []AgentVersionListItem `json:"versions"`
 }
 
+// CreateAgentOpts is the input for AgentRepository.Create (REST path).
 type CreateAgentOpts struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
 }
 
+// CreateAgentFromWizardOpts is the input for AgentRepository.CreateFromWizard
+// (wizard path). The repository creates the agents row + the initial INITIALIZING
+// AgentVersion row in a single transaction.
 type CreateAgentFromWizardOpts struct {
-	ID                string
+	ID                string          // optional pre-generated agent id
 	Name              string
 	FlowMapConfig     json.RawMessage // pre-marshaled JSONB; nil if parse failed
-	FlowMapParseError string          // empty when parse succeeded
+	FlowMapParseError string
 	DiscoveryFilePath string
 }
 
@@ -66,9 +78,5 @@ func NewAgent(opts CreateAgentOpts) (*Agent, error) {
 	if opts.Name == "" {
 		return nil, ErrNameRequired
 	}
-	return &Agent{
-		Name:        opts.Name,
-		Description: opts.Description,
-		Status:      string(AgentStatusDraft),
-	}, nil
+	return &Agent{Name: opts.Name, Description: opts.Description}, nil
 }

--- a/open-bbcd/internal/types/agent_test.go
+++ b/open-bbcd/internal/types/agent_test.go
@@ -16,9 +16,6 @@ func TestNewAgent_Valid(t *testing.T) {
 	if agent.Name != opts.Name {
 		t.Errorf("Name = %q, want %q", agent.Name, opts.Name)
 	}
-	if agent.Status != string(AgentStatusDraft) {
-		t.Errorf("Status = %q, want %q", agent.Status, AgentStatusDraft)
-	}
 }
 
 func TestNewAgent_MissingName(t *testing.T) {

--- a/open-bbcd/internal/types/chat.go
+++ b/open-bbcd/internal/types/chat.go
@@ -6,11 +6,11 @@ import (
 )
 
 type ChatSession struct {
-	ID        string    `json:"id"`
-	AgentID   string    `json:"agent_id"`
-	Title     string    `json:"title,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID             string    `json:"id"`
+	AgentVersionID string    `json:"agent_version_id"`
+	Title          string    `json:"title,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 type ChatRole string

--- a/open-bbcd/migrations/013_split_agents_and_versions.sql
+++ b/open-bbcd/migrations/013_split_agents_and_versions.sql
@@ -1,0 +1,150 @@
+-- migrations/013_split_agents_and_versions.sql
+--
+-- Split the monolithic agents table into:
+--   - agents (per logical agent: name, description, discovery_file_path)
+--   - agent_versions (per version: status, bundle, flow_map_config,
+--     flow_map_parse_error, parent_version_id, timestamps)
+--
+-- flow_map_config + flow_map_parse_error live on agent_versions from the
+-- start: a version is a frozen "spec + bundle" snapshot, and editing the
+-- spec spawns a new version (future workflow). The agents row holds only
+-- the immutable starting point (name, description, discovery_file_path).
+--
+-- FK redirects:
+--   - agent_versions.agent_id -> agents.id (was self-FK to the old agents table)
+--   - chat_sessions: column rename agent_id -> agent_version_id, FK target agent_versions
+--   - deployed_sessions.agent_id stays pointing at the per-agent ID, FK redirected to the new agents
+--   - deployed_messages.agent_version_id keeps its meaning; FK target is the renamed agent_versions
+-- The CHECK constraint agents_root_self_reference goes away (the real FK replaces it).
+
+-- +goose Up
+-- Step 1: rename the existing table out of the way.
+ALTER TABLE agents RENAME TO agent_versions;
+ALTER INDEX agents_pkey RENAME TO agent_versions_pkey;
+ALTER INDEX agents_one_deployed_per_agent RENAME TO agent_versions_one_deployed_per_agent;
+ALTER INDEX idx_agents_agent_id RENAME TO idx_agent_versions_agent_id;
+ALTER INDEX idx_agents_parent_version_id RENAME TO idx_agent_versions_parent_version_id;
+ALTER TABLE agent_versions DROP CONSTRAINT agents_root_self_reference;
+ALTER TABLE agent_versions DROP CONSTRAINT agents_status_check;
+ALTER TABLE agent_versions ADD CONSTRAINT agent_versions_status_check
+  CHECK (status IN ('INITIALIZING','DRAFT','TRAINING','READY','DEPLOYED'));
+
+-- Step 2: create the new agents table with the per-agent fields.
+-- flow_map_config + flow_map_parse_error are NOT here — they stay on agent_versions.
+CREATE TABLE agents (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name                 TEXT NOT NULL,
+    description          TEXT,
+    discovery_file_path  TEXT,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Step 3: backfill agents from the root version of each existing agent.
+-- The root version row is the one where agent_id = id (post-PR#27 invariant).
+INSERT INTO agents (id, name, description, discovery_file_path, created_at)
+SELECT id, name, description, discovery_file_path, created_at
+FROM agent_versions
+WHERE id = agent_id;
+
+-- Step 4: drop now-redundant per-agent columns from agent_versions.
+-- flow_map_config + flow_map_parse_error stay — they're per-version.
+ALTER TABLE agent_versions DROP COLUMN name;
+ALTER TABLE agent_versions DROP COLUMN description;
+ALTER TABLE agent_versions DROP COLUMN discovery_file_path;
+
+-- Step 5: agent_versions.agent_id was a self-FK to the old agents table (renamed).
+-- Repoint it at the new agents table.
+ALTER TABLE agent_versions DROP CONSTRAINT agents_chain_root_id_fkey;
+ALTER TABLE agent_versions ADD CONSTRAINT agent_versions_agent_id_fkey
+  FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE;
+
+-- Step 6: parent_version_id was a self-FK on agents (renamed). Keep it pointing at agent_versions.
+-- Postgres tracks the rename automatically; just rename the constraint for clarity.
+ALTER TABLE agent_versions RENAME CONSTRAINT agents_parent_version_id_fkey TO agent_versions_parent_version_id_fkey;
+
+-- Step 7: chat_sessions column rename.
+ALTER TABLE chat_sessions RENAME COLUMN agent_id TO agent_version_id;
+ALTER TABLE chat_sessions DROP CONSTRAINT chat_sessions_agent_id_fkey;
+ALTER TABLE chat_sessions ADD CONSTRAINT chat_sessions_agent_version_id_fkey
+  FOREIGN KEY (agent_version_id) REFERENCES agent_versions(id) ON DELETE CASCADE;
+ALTER INDEX idx_chat_sessions_agent_id_created RENAME TO idx_chat_sessions_agent_version_id_created;
+
+-- Step 8: deployed_sessions.agent_id FK was pointing at the old agents (now agent_versions).
+-- The DATA in that column is the agent_id (which is what we want); only the FK target needs to change.
+ALTER TABLE deployed_sessions DROP CONSTRAINT deployed_sessions_chain_root_id_fkey;
+ALTER TABLE deployed_sessions ADD CONSTRAINT deployed_sessions_agent_id_fkey
+  FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE;
+
+-- Step 8b: resources.agent_id was pointing at the old agents table (now agent_versions).
+-- Redirect to the new per-agent agents table. Resources are conceptually per-agent
+-- (the route /agents/{agent_id}/resources implies this), but pre-split they were
+-- stored against version-row IDs. Dev DB has 0 resources today, so no data migration.
+ALTER TABLE resources DROP CONSTRAINT resources_agent_id_fkey;
+ALTER TABLE resources ADD CONSTRAINT resources_agent_id_fkey
+  FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE;
+
+-- Step 9: deployed_messages.agent_version_id FK is fine — it always referenced the old agents.id
+-- which is now agent_versions.id (Postgres tracks the rename). The constraint is already named
+-- deployed_messages_agent_version_id_fkey from migration 011 onward, so no rename needed.
+
+-- +goose Down
+-- Reverse order. Best-effort restoration; production rollback path is "goose down on a fresh DB".
+-- Restores the pre-split shape where the (singular) agents table held name, description,
+-- flow_map_config, flow_map_parse_error, discovery_file_path alongside the per-version fields.
+
+ALTER TABLE chat_sessions RENAME COLUMN agent_version_id TO agent_id;
+ALTER TABLE chat_sessions DROP CONSTRAINT chat_sessions_agent_version_id_fkey;
+ALTER INDEX idx_chat_sessions_agent_version_id_created RENAME TO idx_chat_sessions_agent_id_created;
+
+ALTER TABLE deployed_sessions DROP CONSTRAINT deployed_sessions_agent_id_fkey;
+
+ALTER TABLE agent_versions DROP CONSTRAINT agent_versions_agent_id_fkey;
+
+-- Drop resources FK now too — it references the new agents table which we're about to DROP.
+-- We'll re-add it after the rename so it points at the renamed-back agents table.
+ALTER TABLE resources DROP CONSTRAINT resources_agent_id_fkey;
+
+-- Restore the per-agent columns that were dropped on the Up. flow_map_config /
+-- flow_map_parse_error already exist on agent_versions (kept from the start), so
+-- we backfill the agents table from those during the rename step below.
+ALTER TABLE agent_versions ADD COLUMN name TEXT;
+ALTER TABLE agent_versions ADD COLUMN description TEXT;
+ALTER TABLE agent_versions ADD COLUMN discovery_file_path TEXT;
+
+UPDATE agent_versions av SET
+  name = a.name,
+  description = a.description,
+  discovery_file_path = a.discovery_file_path
+FROM agents a
+WHERE av.agent_id = a.id;
+
+ALTER TABLE agent_versions ALTER COLUMN name SET NOT NULL;
+
+DROP TABLE agents;
+
+ALTER TABLE agent_versions RENAME TO agents;
+ALTER INDEX agent_versions_pkey RENAME TO agents_pkey;
+ALTER INDEX agent_versions_one_deployed_per_agent RENAME TO agents_one_deployed_per_agent;
+ALTER INDEX idx_agent_versions_agent_id RENAME TO idx_agents_agent_id;
+ALTER INDEX idx_agent_versions_parent_version_id RENAME TO idx_agents_parent_version_id;
+
+ALTER TABLE chat_sessions ADD CONSTRAINT chat_sessions_agent_id_fkey
+  FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE;
+ALTER TABLE deployed_sessions ADD CONSTRAINT deployed_sessions_chain_root_id_fkey
+  FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE;
+ALTER TABLE agents ADD CONSTRAINT agents_chain_root_id_fkey
+  FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE;
+
+-- Restore resources FK to the renamed-back agents table (post-DROP-TABLE + post-RENAME,
+-- this is the former agent_versions). The constraint was dropped above before DROP TABLE.
+ALTER TABLE resources ADD CONSTRAINT resources_agent_id_fkey
+  FOREIGN KEY (agent_id) REFERENCES agents(id) ON DELETE CASCADE;
+
+-- Restore the parent_version_id FK constraint name so Up's rename in step 6 finds it.
+ALTER TABLE agents RENAME CONSTRAINT agent_versions_parent_version_id_fkey TO agents_parent_version_id_fkey;
+
+ALTER TABLE agents DROP CONSTRAINT agent_versions_status_check;
+ALTER TABLE agents ADD CONSTRAINT agents_status_check
+  CHECK (status IN ('INITIALIZING','DRAFT','TRAINING','READY','DEPLOYED'));
+ALTER TABLE agents ADD CONSTRAINT agents_root_self_reference
+  CHECK (parent_version_id IS NOT NULL OR agent_id = id);

--- a/open-bbcd/web/static/chat.js
+++ b/open-bbcd/web/static/chat.js
@@ -1,5 +1,5 @@
 // chat.js — vanilla JS chat client.
-// Subscribes to AG-UI SSE stream from POST /agents/{id}/chat/{session_id}/turn.
+// Subscribes to AG-UI SSE stream from POST /agent_versions/{version_id}/chat/{session_id}/turn.
 //
 // AG-UI Go SDK wire format (NOT W3C `event: TYPE` headers):
 //   id: <event_id>
@@ -27,9 +27,9 @@
 
   const input = document.getElementById('chat-input');
   const sendBtn = document.getElementById('chat-send');
-  const agentID = log.dataset.agentId;
+  const versionID = log.dataset.versionId;
   const sessionID = log.dataset.sessionId;
-  if (!agentID || !sessionID) return;
+  if (!versionID || !sessionID) return;
 
   let currentAssistantTurn = null;
   let displayBuf = '';
@@ -68,7 +68,7 @@
     startAssistantBubble();
 
     try {
-      const resp = await fetch(`/agents/${agentID}/chat/${sessionID}/turn`, {
+      const resp = await fetch(`/agent_versions/${versionID}/chat/${sessionID}/turn`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ input: [{ type: 'text', text }] }),
@@ -402,7 +402,7 @@
       e.preventDefault();
       const newTitle = input.value.trim();
       try {
-        const res = await fetch(`/agents/${agentID}/chat/${sessionID}/title`, {
+        const res = await fetch(`/agent_versions/${versionID}/chat/${sessionID}/title`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ title: newTitle }),

--- a/open-bbcd/web/static/openbbc-flow.js
+++ b/open-bbcd/web/static/openbbc-flow.js
@@ -199,7 +199,7 @@
   // Markup contract for a workflow-editor container:
   //   <div class="obf-editor"
   //        data-obf-editor
-  //        data-agent-id="<uuid>"
+  //        data-version-id="<uuid>"
   //        data-flow-id="<flow-id>"
   //        data-skills='["skill-id-1","skill-id-2",...]'>
   //     <div class="obf-toolbar">
@@ -518,7 +518,7 @@
     async function doSave() {
       const next = currentWorkflow();
       const mermaid = OpenBBCFlow.serializeMermaid(next);
-      const url = `/agents/${root.dataset.agentId}/configure/flows/${root.dataset.flowId}/workflow`;
+      const url = `/agent_versions/${root.dataset.versionId}/configure/flows/${root.dataset.flowId}/workflow`;
       try {
         const res = await fetch(url, {
           method: "POST",

--- a/open-bbcd/web/templates/agent-deploy-modal.html
+++ b/open-bbcd/web/templates/agent-deploy-modal.html
@@ -10,7 +10,8 @@
       <code>/deployed/{{.AgentID}}</code>
     {{end}}
     <div class="modal-actions">
-      <button hx-post="/agents/{{.Version.ID}}/deploy"
+      <button hx-post="/agents/{{.AgentID}}/deploy"
+              hx-vals='{"version_id":"{{.Version.ID}}"}'
               hx-on::after-request="window.location.reload()">
         Confirm Deploy
       </button>

--- a/open-bbcd/web/templates/agent-undeploy-modal.html
+++ b/open-bbcd/web/templates/agent-undeploy-modal.html
@@ -5,7 +5,7 @@
     <p>Take this version offline?</p>
     <p><code>/deployed/{{.AgentID}}</code> will return 404 until you deploy another version of this agent.</p>
     <div class="modal-actions">
-      <button hx-post="/agents/{{.Version.ID}}/undeploy"
+      <button hx-post="/agents/{{.AgentID}}/undeploy"
               hx-on::after-request="window.location.reload()">
         Confirm Undeploy
       </button>

--- a/open-bbcd/web/templates/agent-versions.html
+++ b/open-bbcd/web/templates/agent-versions.html
@@ -15,21 +15,21 @@
   </thead>
   <tbody>
     {{range .Versions}}
-    {{$href := printf "/agents/%s/configure" .Agent.ID}}
+    {{$href := printf "/agent_versions/%s/configure" .Version.ID}}
     <tr>
       <td class="col-version {{if gt .VersionNum 1}}old{{end}}">
         <a class="agent-link" href="{{$href}}">v{{.VersionNum}}</a>
       </td>
-      <td class="col-status"><span class="badge badge-{{.Agent.Status | statusClass}}">{{.Agent.Status}}</span></td>
-      <td class="col-date">{{.Agent.CreatedAt.Format "Jan 2, 2006"}}</td>
+      <td class="col-status"><span class="badge badge-{{.Version.Status | statusClass}}">{{.Version.Status}}</span></td>
+      <td class="col-date">{{.Version.CreatedAt.Format "Jan 2, 2006"}}</td>
       <td class="col-actions">
-        {{if eq .Agent.Status "READY"}}
+        {{if eq .Version.Status "READY"}}
           <button class="btn-small"
-                  hx-get="/agents/{{.Agent.ID}}/deploy/confirm"
+                  hx-get="/agents/{{$.AgentID}}/deploy/confirm?version_id={{.Version.ID}}"
                   hx-target="body" hx-swap="beforeend">Deploy</button>
-        {{else if eq .Agent.Status "DEPLOYED"}}
+        {{else if eq .Version.Status "DEPLOYED"}}
           <button class="btn-small btn-danger"
-                  hx-get="/agents/{{.Agent.ID}}/undeploy/confirm"
+                  hx-get="/agents/{{$.AgentID}}/undeploy/confirm"
                   hx-target="body" hx-swap="beforeend">Undeploy</button>
         {{end}}
       </td>

--- a/open-bbcd/web/templates/agents.html
+++ b/open-bbcd/web/templates/agents.html
@@ -21,8 +21,8 @@
     <tr class="clickable" onclick="location.href=this.dataset.href" data-href="/agents/ui?agent={{.AgentID}}">
       <td><a class="agent-link" href="/agents/ui?agent={{.AgentID}}">{{.Name}}</a></td>
       <td class="col-version">v{{$latest.VersionNum}}</td>
-      <td class="col-status"><span class="badge badge-{{$latest.Agent.Status | statusClass}}">{{$latest.Agent.Status}}</span></td>
-      <td class="col-date">{{$latest.Agent.CreatedAt.Format "Jan 2, 2006"}}</td>
+      <td class="col-status"><span class="badge badge-{{$latest.Version.Status | statusClass}}">{{$latest.Version.Status}}</span></td>
+      <td class="col-date">{{$latest.Version.CreatedAt.Format "Jan 2, 2006"}}</td>
       <td class="col-count">{{len .Versions}}</td>
     </tr>
     {{end}}

--- a/open-bbcd/web/templates/chat/sessions.html
+++ b/open-bbcd/web/templates/chat/sessions.html
@@ -5,7 +5,7 @@
     <a href="/agents/ui?agent={{.AgentID}}" class="back-link">← {{.AgentName}}</a>
     <h1>Sessions</h1>
   </div>
-  <form method="post" action="/agents/{{.AgentID}}/chat/sessions" class="inline">
+  <form method="post" action="/agent_versions/{{.VersionID}}/chat/sessions" class="inline">
     <button type="submit" class="btn-primary">+ New Session</button>
   </form>
 </div>
@@ -21,12 +21,12 @@
   </thead>
   <tbody>
     {{range .Sessions}}
-    <tr class="clickable" onclick="location.href=this.dataset.href" data-href="/agents/{{$.AgentID}}/chat/{{.ID}}">
+    <tr class="clickable" onclick="location.href=this.dataset.href" data-href="/agent_versions/{{$.VersionID}}/chat/{{.ID}}">
       <td>
         {{if .Title}}
-          <a class="session-link" href="/agents/{{$.AgentID}}/chat/{{.ID}}">{{.Title}}</a>
+          <a class="session-link" href="/agent_versions/{{$.VersionID}}/chat/{{.ID}}">{{.Title}}</a>
         {{else}}
-          <a class="session-link untitled" href="/agents/{{$.AgentID}}/chat/{{.ID}}">Untitled session</a>
+          <a class="session-link untitled" href="/agent_versions/{{$.VersionID}}/chat/{{.ID}}">Untitled session</a>
         {{end}}
       </td>
       <td class="col-date">{{.CreatedAt.Format "Jan 2, 2006 15:04"}}</td>

--- a/open-bbcd/web/templates/chat/view.html
+++ b/open-bbcd/web/templates/chat/view.html
@@ -20,14 +20,14 @@
     <div class="session-subtitle">{{.AgentName}}</div>
   </div>
   <div class="chat-actions">
-    <a href="/agents/{{.AgentID}}/chat" class="btn-secondary">Sessions</a>
-    <form method="post" action="/agents/{{.AgentID}}/chat/sessions" style="display:inline">
+    <a href="/agent_versions/{{.VersionID}}/chat" class="btn-secondary">Sessions</a>
+    <form method="post" action="/agent_versions/{{.VersionID}}/chat/sessions" style="display:inline">
       <button type="submit" class="btn-primary">+ New Session</button>
     </form>
   </div>
 </div>
 
-<div id="chat-log" class="chat-log" data-agent-id="{{.AgentID}}" data-session-id="{{.SessionID}}">
+<div id="chat-log" class="chat-log" data-version-id="{{.VersionID}}" data-session-id="{{.SessionID}}">
   {{range .Messages}}
     <div class="chat-bubble {{.Role}}">
       <div class="bubble-header">

--- a/open-bbcd/web/templates/configurator/capabilities.html
+++ b/open-bbcd/web/templates/configurator/capabilities.html
@@ -6,14 +6,14 @@
   <aside class="config-list">
     <div class="config-list-header">Capabilities ({{len .Config.Capabilities}})</div>
     {{range .Config.Capabilities}}
-      {{template "capability_row" (dict "AgentID" $.AgentID "Cap" . "SelectedID" (selectedCapName $.SelectedCap))}}
+      {{template "capability_row" (dict "VersionID" $.VersionID "Cap" . "SelectedID" (selectedCapName $.SelectedCap))}}
     {{else}}
       <p class="empty-state">No capabilities in this discovery snapshot.</p>
     {{end}}
   </aside>
   <main class="config-detail-pane">
     {{if .SelectedCap}}
-      {{template "capability_detail" (dict "AgentID" .AgentID "Cap" .SelectedCap)}}
+      {{template "capability_detail" (dict "VersionID" .VersionID "Cap" .SelectedCap)}}
     {{else}}
       <p class="config-detail-empty">Select a capability on the left.</p>
     {{end}}

--- a/open-bbcd/web/templates/configurator/finalize.html
+++ b/open-bbcd/web/templates/configurator/finalize.html
@@ -31,9 +31,9 @@
     </div>
   </div>
 
-  <form method="POST" action="/agents/{{.AgentID}}/finalize" class="config-finalize-form">
+  <form method="POST" action="/agent_versions/{{.VersionID}}/finalize" class="config-finalize-form">
     <button type="submit" class="btn-primary">Yes, finalize →</button>
-    <a href="/agents/{{.AgentID}}/configure/flows" class="btn-secondary">Cancel</a>
+    <a href="/agent_versions/{{.VersionID}}/configure/flows" class="btn-secondary">Cancel</a>
   </form>
 </div>
 {{end}}

--- a/open-bbcd/web/templates/configurator/flows.html
+++ b/open-bbcd/web/templates/configurator/flows.html
@@ -3,14 +3,14 @@
   <aside class="config-list">
     <div class="config-list-header">Flows ({{len .Config.Flows}})</div>
     {{range .Config.Flows}}
-      {{template "flow_row" (dict "AgentID" $.AgentID "Flow" . "SelectedID" (selectedFlowID $.SelectedFlow) "ReadOnly" $.ReadOnly)}}
+      {{template "flow_row" (dict "VersionID" $.VersionID "Flow" . "SelectedID" (selectedFlowID $.SelectedFlow) "ReadOnly" $.ReadOnly)}}
     {{else}}
       <p class="empty-state">No flows in this discovery snapshot.</p>
     {{end}}
   </aside>
   <main class="config-detail-pane">
     {{if .SelectedFlow}}
-      {{template "flow_detail" (dict "AgentID" .AgentID "Flow" .SelectedFlow "Skills" .Config.Skills "ReadOnly" .ReadOnly)}}
+      {{template "flow_detail" (dict "VersionID" .VersionID "Flow" .SelectedFlow "Skills" .Config.Skills "ReadOnly" .ReadOnly)}}
     {{else}}
       <p class="config-detail-empty">Select a flow on the left.</p>
     {{end}}

--- a/open-bbcd/web/templates/configurator/layout.html
+++ b/open-bbcd/web/templates/configurator/layout.html
@@ -7,9 +7,9 @@
     {{if .ReadOnly}}
     <span class="config-spacer"></span>
     <div class="config-actions">
-      <a href="/agents/{{.AgentID}}/config.yaml" class="btn-secondary">Download YAML</a>
+      <a href="/agent_versions/{{.VersionID}}/config.yaml" class="btn-secondary">Download YAML</a>
       {{if .HasBundle}}
-        <form method="post" action="/agents/{{.AgentID}}/chat/sessions" style="display:inline">
+        <form method="post" action="/agent_versions/{{.VersionID}}/chat/sessions" style="display:inline">
           <button type="submit" class="btn-primary">Run</button>
         </form>
       {{else}}
@@ -22,18 +22,18 @@
   </div>
 
   <nav class="config-tabs">
-    <a href="/agents/{{.AgentID}}/configure/flows"
+    <a href="/agent_versions/{{.VersionID}}/configure/flows"
        class="config-tab {{if eq .Tab "flows"}}active{{end}}">Flows</a>
-    <a href="/agents/{{.AgentID}}/configure/skills"
+    <a href="/agent_versions/{{.VersionID}}/configure/skills"
        class="config-tab {{if eq .Tab "skills"}}active{{end}}">Skills</a>
-    <a href="/agents/{{.AgentID}}/configure/capabilities"
+    <a href="/agent_versions/{{.VersionID}}/configure/capabilities"
        class="config-tab {{if eq .Tab "capabilities"}}active{{end}}">Capabilities</a>
     {{if .ReadOnly}}
-    <a href="/agents/{{.AgentID}}/configure/inputs"
+    <a href="/agent_versions/{{.VersionID}}/configure/inputs"
        class="config-tab {{if eq .Tab "inputs"}}active{{end}}">Inputs</a>
     {{else}}
     <span class="config-spacer"></span>
-    <a href="/agents/{{.AgentID}}/configure/finalize"
+    <a href="/agent_versions/{{.VersionID}}/configure/finalize"
        class="config-tab {{if eq .Tab "finalize"}}active{{end}}">Finalize →</a>
     {{end}}
   </nav>

--- a/open-bbcd/web/templates/configurator/partials.html
+++ b/open-bbcd/web/templates/configurator/partials.html
@@ -3,13 +3,13 @@
   <input type="checkbox" class="config-list-row-toggle"
          {{if .Flow.Included}}checked{{end}}
          {{if .ReadOnly}}disabled{{else}}
-         hx-post="/agents/{{.AgentID}}/configure/flows/{{.Flow.ID}}/included"
+         hx-post="/agent_versions/{{.VersionID}}/configure/flows/{{.Flow.ID}}/included"
          hx-trigger="change"
          hx-vals='js:{included: event.target.checked}'
          hx-target="#flow-row-{{.Flow.ID}}"
          hx-swap="outerHTML"
          {{end}}>
-  <a href="/agents/{{.AgentID}}/configure/flows/{{.Flow.ID}}" class="config-list-row-link">
+  <a href="/agent_versions/{{.VersionID}}/configure/flows/{{.Flow.ID}}" class="config-list-row-link">
     <span class="config-list-row-name">{{.Flow.ID}}</span>
     <span class="config-list-row-meta">{{workflowNodeCount .Flow.Workflow}} nodes</span>
   </a>
@@ -26,7 +26,7 @@
     <div class="obf-editor"
          data-obf-editor
          {{if .ReadOnly}}data-obf-readonly="1"{{end}}
-         data-agent-id="{{.AgentID}}"
+         data-version-id="{{.VersionID}}"
          data-flow-id="{{.Flow.ID}}"
          data-skills='{{json (skillIds .Skills)}}'>
       {{if not .ReadOnly}}
@@ -65,7 +65,7 @@
   {{if .Flow.ProseMD}}
   <div class="config-section">
     <h3>Description (from discovery)</h3>
-    <div class="prose">{{renderMarkdown .AgentID .Flow.ProseMD}}</div>
+    <div class="prose">{{renderMarkdown .VersionID .Flow.ProseMD}}</div>
   </div>
   {{end}}
 </div>
@@ -73,7 +73,7 @@
 
 {{define "skill_row"}}
 <div id="skill-row-{{.Skill.ID}}">
-  <a href="/agents/{{.AgentID}}/configure/skills/{{.Skill.ID}}"
+  <a href="/agent_versions/{{.VersionID}}/configure/skills/{{.Skill.ID}}"
      class="config-list-row {{if and .SelectedID (eq .SelectedID .Skill.ID)}}selected{{end}}">
     <span class="config-list-row-name">{{.Skill.ID}}</span>
     <span class="config-list-row-meta">
@@ -86,7 +86,7 @@
 {{end}}
 
 {{define "skill_form_fields"}}
-<input type="hidden" name="agent_id" value="{{.AgentID}}">
+<input type="hidden" name="version_id" value="{{.VersionID}}">
 
 <label>Name
   <input type="text" name="name" value="{{.Skill.Name}}" required>
@@ -145,14 +145,14 @@
 
   <form class="config-form {{if .ReadOnly}}config-form-readonly{{end}}"
         {{if not .ReadOnly}}
-        hx-post="/agents/{{.AgentID}}/configure/skills/{{.Skill.ID}}"
+        hx-post="/agent_versions/{{.VersionID}}/configure/skills/{{.Skill.ID}}"
         hx-target="closest .config-detail"
         hx-swap="outerHTML"
         hx-indicator=".config-form-saved"
         {{end}}>
     <fieldset {{if .ReadOnly}}disabled{{end}} style="border:none;padding:0;margin:0;display:contents">
     {{template "skill_form_fields" (dict
-      "AgentID"     .AgentID
+      "VersionID"   .VersionID
       "Skill"       .Skill
       "Capabilities" .Capabilities)}}
     </fieldset>
@@ -163,7 +163,7 @@
       {{if eq .Skill.Origin "custom"}}
       <button type="button"
               class="btn-secondary danger-button"
-              hx-delete="/agents/{{.AgentID}}/configure/skills/{{.Skill.ID}}"
+              hx-delete="/agent_versions/{{.VersionID}}/configure/skills/{{.Skill.ID}}"
               hx-target="#skill-row-{{.Skill.ID}}"
               hx-swap="delete"
               hx-confirm="Delete this custom skill?">Delete</button>
@@ -176,7 +176,7 @@
   {{if .Skill.ProseMD}}
   <div class="config-section">
     <h3>Source (from discovery)</h3>
-    <div class="prose">{{renderMarkdown .AgentID .Skill.ProseMD}}</div>
+    <div class="prose">{{renderMarkdown .VersionID .Skill.ProseMD}}</div>
   </div>
   {{end}}
 </div>
@@ -188,12 +188,12 @@
   <p class="config-detail-id">A new id will be generated from the name.</p>
 
   <form class="config-form"
-        hx-post="/agents/{{.AgentID}}/configure/skills"
+        hx-post="/agent_versions/{{.VersionID}}/configure/skills"
         hx-target="#skill-list-rows"
         hx-swap="beforeend"
         hx-indicator=".config-form-saved">
     {{template "skill_form_fields" (dict
-      "AgentID"     .AgentID
+      "VersionID"   .VersionID
       "Skill"       .Skill
       "Capabilities" .Capabilities)}}
 
@@ -206,7 +206,7 @@
 {{end}}
 
 {{define "capability_row"}}
-<a href="/agents/{{.AgentID}}/configure/capabilities/{{.Cap.Name}}"
+<a href="/agent_versions/{{.VersionID}}/configure/capabilities/{{.Cap.Name}}"
    class="config-list-row {{if and .SelectedID (eq .SelectedID .Cap.Name)}}selected{{end}}">
   <span class="config-list-row-name">{{.Cap.Name}}</span>
   <span class="config-list-row-meta"><span class="muted">{{len .Cap.Tools}} tools</span></span>
@@ -238,7 +238,7 @@
   {{if .Cap.ProseMD}}
   <div class="config-section">
     <h3>Documentation (from discovery)</h3>
-    <div class="prose">{{renderMarkdown .AgentID .Cap.ProseMD}}</div>
+    <div class="prose">{{renderMarkdown .VersionID .Cap.ProseMD}}</div>
   </div>
   {{end}}
 </div>

--- a/open-bbcd/web/templates/configurator/skills.html
+++ b/open-bbcd/web/templates/configurator/skills.html
@@ -4,21 +4,21 @@
     <div class="config-list-header">Skills ({{len .Config.Skills}})</div>
     <div id="skill-list-rows">
       {{range .Config.Skills}}
-        {{template "skill_row" (dict "AgentID" $.AgentID "Skill" . "SelectedID" (selectedSkillID $.SelectedSkill))}}
+        {{template "skill_row" (dict "VersionID" $.VersionID "Skill" . "SelectedID" (selectedSkillID $.SelectedSkill))}}
       {{else}}
         <p class="empty-state">No skills in this discovery snapshot.</p>
       {{end}}
     </div>
     {{if not .ReadOnly}}
     <button class="skill-add-trigger"
-            hx-get="/agents/{{.AgentID}}/configure/skills/new"
+            hx-get="/agent_versions/{{.VersionID}}/configure/skills/new"
             hx-target=".config-detail-pane"
             hx-swap="innerHTML">+ Add skill</button>
     {{end}}
   </aside>
   <main class="config-detail-pane">
     {{if .SelectedSkill}}
-      {{template "skill_detail" (dict "AgentID" .AgentID "Skill" .SelectedSkill "Capabilities" .Config.Capabilities "ReadOnly" .ReadOnly)}}
+      {{template "skill_detail" (dict "VersionID" .VersionID "Skill" .SelectedSkill "Capabilities" .Config.Capabilities "ReadOnly" .ReadOnly)}}
     {{else}}
       <p class="config-detail-empty">{{if .ReadOnly}}Select a skill on the left to preview.{{else}}Select a skill on the left or click + Add skill.{{end}}</p>
     {{end}}

--- a/scripts/seed_bundle.py
+++ b/scripts/seed_bundle.py
@@ -6,14 +6,14 @@
 #     "pyyaml>=6.0",
 # ]
 # ///
-"""Seed a bundle YAML into agents.bundle JSONB.
+"""Seed a bundle YAML into agent_versions.bundle JSONB.
 
 Usage:
     DATABASE_URL=postgres://... \\
-        uv run scripts/seed_bundle.py --agent-id <uuid> --bundle path/to/bundle.yaml [--force]
+        uv run scripts/seed_bundle.py --version-id <uuid> --bundle path/to/bundle.yaml [--force]
 
 Without --force, refuses to overwrite a non-NULL bundle. With --force,
-overwrites (dev escape hatch for when no chat sessions reference the row).
+overwrites (dev escape hatch for when no chat sessions reference the version).
 """
 
 import argparse
@@ -27,7 +27,7 @@ import yaml
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--agent-id", required=True, help="UUID of the agent (version row) to seed")
+    p.add_argument("--version-id", required=True, help="UUID of the agent_versions row to seed")
     p.add_argument("--bundle", required=True, help="Path to bundle YAML file")
     p.add_argument("--force", action="store_true", help="Overwrite a non-NULL bundle")
     args = p.parse_args()
@@ -55,27 +55,27 @@ def main() -> int:
             # also flip status to 'READY' in the same write.
             if args.force:
                 cur.execute(
-                    "UPDATE agents SET bundle = %s::jsonb, status = 'READY', "
+                    "UPDATE agent_versions SET bundle = %s::jsonb, status = 'READY', "
                     "updated_at = now() WHERE id = %s::uuid",
-                    (payload, args.agent_id),
+                    (payload, args.version_id),
                 )
             else:
                 cur.execute(
-                    "UPDATE agents SET bundle = %s::jsonb, status = 'READY', "
+                    "UPDATE agent_versions SET bundle = %s::jsonb, status = 'READY', "
                     "updated_at = now() WHERE id = %s::uuid AND bundle IS NULL",
-                    (payload, args.agent_id),
+                    (payload, args.version_id),
                 )
 
             if cur.rowcount == 0:
-                # Distinguish "agent doesn't exist" from "bundle already set".
+                # Distinguish "version doesn't exist" from "bundle already set".
                 cur.execute(
-                    "SELECT EXISTS(SELECT 1 FROM agents WHERE id = %s::uuid), "
-                    "COALESCE((SELECT bundle IS NOT NULL FROM agents WHERE id = %s::uuid), false)",
-                    (args.agent_id, args.agent_id),
+                    "SELECT EXISTS(SELECT 1 FROM agent_versions WHERE id = %s::uuid), "
+                    "COALESCE((SELECT bundle IS NOT NULL FROM agent_versions WHERE id = %s::uuid), false)",
+                    (args.version_id, args.version_id),
                 )
                 exists, has_bundle = cur.fetchone()
                 if not exists:
-                    print("error: agent not found", file=sys.stderr)
+                    print("error: version not found", file=sys.stderr)
                     return 1
                 if has_bundle and not args.force:
                     print("error: bundle already set; use --force to overwrite", file=sys.stderr)
@@ -87,7 +87,7 @@ def main() -> int:
         print(f"error: database connection: {e}", file=sys.stderr)
         return 1
 
-    print(f"✓ bundle written for agent {args.agent_id} ({len(payload)} bytes), status=READY")
+    print(f"✓ bundle written for version {args.version_id} ({len(payload)} bytes), status=READY")
     return 0
 
 


### PR DESCRIPTION
Closes #28.

## Summary

Replaces the single denormalized `agents` table (where each row was a *version* with per-agent fields duplicated across versions) with a real two-table model: `agents` (per logical agent) + `agent_versions` (per version). Renames Go types accordingly, fixes URL nomenclature so version-scoped routes say so, and moves flow-map config onto the version (each version freezes its own spec).

## Final shape

\`\`\`
agents                                  agent_versions
─────────                               ─────────────
id                                      id
name                                    agent_id (FK → agents.id, ON DELETE CASCADE)
description                             parent_version_id (FK self, NULL on root)
discovery_file_path                     status
created_at                              bundle
                                        flow_map_config
                                        flow_map_parse_error
                                        created_at, updated_at
\`\`\`

- `agent_id` is now a real FK to a real table. The CHECK + self-FK + partial-unique-index dance from PR #27 (which propped up "chain identity" inside a single table) goes away.
- Partial unique index "one DEPLOYED per agent" stays — now on `agent_versions(agent_id) WHERE status = 'DEPLOYED'`.
- `discovery_file_path` is the immutable input on the agent; everything that gets edited over time (flow-map spec, bundle, status) lives on the version.

## URL renames

| Was | Now | Why |
|---|---|---|
| `POST /agents/{id}/deploy` (id = version) | `POST /agents/{agent_id}/deploy` body `{version_id}` | Verb on the agent |
| `POST /agents/{id}/undeploy` | `POST /agents/{agent_id}/undeploy` | Verb on the agent; resolves current internally |
| `GET/POST /agents/{id}/chat/...` | `GET/POST /agent_versions/{version_id}/chat/...` | Sessions are version-pinned |
| `GET /agents/{id}/configure/...` | `GET /agent_versions/{version_id}/configure/...` | Configurator edits a specific version |
| `GET /agents/{id}` JSON | `GET /agents/{agent_id}` returning per-agent record | Honest |
| `/deployed/{agent_id}/sessions/...` | unchanged | Already correct |
| `GET /agents/ui` listing | unchanged | Per-agent listing |

No backwards-compat URL shims — alpha service, no external integrations.

## Type rename

- `types.Agent` (formerly a version row) → per-agent record (`id, name, description, discovery_file_path, created_at`).
- `types.AgentVersion` (formerly the `{Agent, VersionNum}` wrapper) → per-version row (`id, agent_id, parent_version_id, status, bundle, flow_map_config, flow_map_parse_error, created_at, updated_at`).
- New `types.AgentVersionListItem{Version, VersionNum}` for UI version-history listings.
- Repository split: `AgentRepository` (per-agent) + `AgentVersionRepository` (per-version, with `GetWithAgent` join helper).
- `ChatStore.EnsureSession` param renamed `agentID` → `scopeID` (impls each interpret it as version-id for BO chat / agent-id for deployed).

## Migration

Single migration `013_split_agents_and_versions.sql` does the full delta: rename existing `agents` → `agent_versions`, create new per-agent `agents`, backfill from root version rows, drop redundant columns from `agent_versions` (keeping `flow_map_config` + `flow_map_parse_error` there), redirect FKs on `chat_sessions` (column renamed `agent_id` → `agent_version_id`), `deployed_sessions`, and `resources`. Down is symmetric.

## Test plan

- [x] `make test` race-clean across all packages.
- [x] Migration 013 up/down/up/down/up cycles clean against dev DB.
- [x] Schema verified: `agents` has per-agent columns only; `agent_versions` has per-version columns + flow_map; `chat_sessions.agent_version_id`; FKs on dependent tables all target the right table.
- [x] E2E smoke against running server: seed agent + READY version → `POST /agents/{aid}/deploy` body `{version_id}` → 200 → `POST /deployed/{aid}/sessions` → 201 → AG-UI SSE turn (`RUN_STARTED` → text deltas → `RUN_FINISHED`) → `deployed_messages.agent_version_id` stamped correctly.
- [x] BO routes: `/agents/ui` 200, `/agent_versions/{vid}/configure` 200.
- [x] Negative paths: unknown agent → 404, missing body → 400, wrong agent → 404.
- [x] `scripts/seed_bundle.py` updated to write `agent_versions.bundle` (flag renamed `--version-id`).

## Out of scope (deferred)

- "Edit flow_map → spawn new agent" / "edit bundle → spawn new version" semantics — the configurator still mutates in place. The schema is now shaped to support these workflows when the FE adds them.
- AG-UI protocol changes, auth, multi-tenancy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)