### PR TITLE
feat(open-bbcd): BO frontend redesign — agent detail + version tabs (Architecture / Prompts)

### DIFF
--- a/open-bbcd/internal/handler/api.go
+++ b/open-bbcd/internal/handler/api.go
@@ -151,6 +151,7 @@ func NewAPI(db *sql.DB, store storage.Storage, cfg *config.Config, logger *slog.
 	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture/capabilities", configuratorHandler.Capabilities)
 	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture/capabilities/{capName}", configuratorHandler.Capabilities)
 	mux.HandleFunc("GET /agent_versions/{version_id}/configure/inputs", configuratorHandler.Inputs)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/prompts", configuratorHandler.Prompts)
 	mux.HandleFunc("POST /agent_versions/{version_id}/configure/architecture/flows/{flowId}/included", configuratorHandler.FlowIncluded)
 	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture/skills/new", configuratorHandler.SkillNew)
 	mux.HandleFunc("POST /agent_versions/{version_id}/configure/architecture/skills", configuratorHandler.SkillCreate)

--- a/open-bbcd/internal/handler/api.go
+++ b/open-bbcd/internal/handler/api.go
@@ -139,24 +139,28 @@ func NewAPI(db *sql.DB, store storage.Storage, cfg *config.Config, logger *slog.
 	mux.HandleFunc("GET /agents/new/step/{n}", uiHandler.WizardStep)
 	mux.HandleFunc("POST /agents/wizard", wizardHandler.Submit)
 
-	// Per-version configurator
+	// Per-version configurator. Flows / Skills / Capabilities are nested under
+	// the Architecture primary tab; Inputs, Finalize, and the YAML download are
+	// siblings. RegisterConfiguratorRedirects below 301s the pre-redesign tab
+	// URLs to their /architecture/ equivalents.
 	mux.HandleFunc("GET /agent_versions/{version_id}/configure", configuratorHandler.Index)
-	mux.HandleFunc("GET /agent_versions/{version_id}/configure/flows", configuratorHandler.Flows)
-	mux.HandleFunc("GET /agent_versions/{version_id}/configure/flows/{flowId}", configuratorHandler.Flows)
-	mux.HandleFunc("GET /agent_versions/{version_id}/configure/skills", configuratorHandler.Skills)
-	mux.HandleFunc("GET /agent_versions/{version_id}/configure/skills/{skillId}", configuratorHandler.Skills)
-	mux.HandleFunc("GET /agent_versions/{version_id}/configure/capabilities", configuratorHandler.Capabilities)
-	mux.HandleFunc("GET /agent_versions/{version_id}/configure/capabilities/{capName}", configuratorHandler.Capabilities)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture/flows", configuratorHandler.Flows)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture/flows/{flowId}", configuratorHandler.Flows)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture/skills", configuratorHandler.Skills)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture/skills/{skillId}", configuratorHandler.Skills)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture/capabilities", configuratorHandler.Capabilities)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture/capabilities/{capName}", configuratorHandler.Capabilities)
 	mux.HandleFunc("GET /agent_versions/{version_id}/configure/inputs", configuratorHandler.Inputs)
-	mux.HandleFunc("POST /agent_versions/{version_id}/configure/flows/{flowId}/included", configuratorHandler.FlowIncluded)
-	mux.HandleFunc("GET /agent_versions/{version_id}/configure/skills/new", configuratorHandler.SkillNew)
-	mux.HandleFunc("POST /agent_versions/{version_id}/configure/skills", configuratorHandler.SkillCreate)
-	mux.HandleFunc("POST /agent_versions/{version_id}/configure/skills/{skillId}", configuratorHandler.SkillUpdate)
-	mux.HandleFunc("DELETE /agent_versions/{version_id}/configure/skills/{skillId}", configuratorHandler.SkillDelete)
-	mux.HandleFunc("POST /agent_versions/{version_id}/configure/flows/{flowId}/workflow", configuratorHandler.WorkflowUpdate)
+	mux.HandleFunc("POST /agent_versions/{version_id}/configure/architecture/flows/{flowId}/included", configuratorHandler.FlowIncluded)
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture/skills/new", configuratorHandler.SkillNew)
+	mux.HandleFunc("POST /agent_versions/{version_id}/configure/architecture/skills", configuratorHandler.SkillCreate)
+	mux.HandleFunc("POST /agent_versions/{version_id}/configure/architecture/skills/{skillId}", configuratorHandler.SkillUpdate)
+	mux.HandleFunc("DELETE /agent_versions/{version_id}/configure/architecture/skills/{skillId}", configuratorHandler.SkillDelete)
+	mux.HandleFunc("POST /agent_versions/{version_id}/configure/architecture/flows/{flowId}/workflow", configuratorHandler.WorkflowUpdate)
 	mux.HandleFunc("GET /agent_versions/{version_id}/configure/finalize", configuratorHandler.FinalizeConfirm)
 	mux.HandleFunc("POST /agent_versions/{version_id}/finalize", configuratorHandler.Finalize)
 	mux.HandleFunc("GET /agent_versions/{version_id}/config.yaml", configuratorHandler.DownloadYAML)
+	RegisterConfiguratorRedirects(mux)
 
 	// Per-version BO chat
 	mux.HandleFunc("POST /agent_versions/{version_id}/chat/sessions", chatHandler.NewSession)

--- a/open-bbcd/internal/handler/api.go
+++ b/open-bbcd/internal/handler/api.go
@@ -75,7 +75,7 @@ func NewAPI(db *sql.DB, store storage.Storage, cfg *config.Config, logger *slog.
 		fatal("parse wizard schema", err)
 	}
 
-	uiHandler, err := NewUIHandler(agentRepo, versionRepo, &schema, web.Assets, logger)
+	uiHandler, err := NewUIHandler(agentRepo, versionRepo, store, &schema, web.Assets, logger)
 	if err != nil {
 		fatal("init UI handler", err)
 	}
@@ -168,6 +168,7 @@ func NewAPI(db *sql.DB, store storage.Storage, cfg *config.Config, logger *slog.
 	// Per-agent deploy/undeploy + confirm modals
 	mux.HandleFunc("POST /agents/{agent_id}/deploy", deployHandler.Deploy)
 	mux.HandleFunc("POST /agents/{agent_id}/undeploy", deployHandler.Undeploy)
+	mux.HandleFunc("GET /agents/{agent_id}/discovery", uiHandler.DiscoveryDownload)
 	mux.HandleFunc("GET /agents/{agent_id}/deploy/confirm", uiHandler.DeployConfirm)
 	mux.HandleFunc("GET /agents/{agent_id}/undeploy/confirm", uiHandler.UndeployConfirm)
 

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -148,6 +148,7 @@ type configPageData struct {
 	SubTab            string // architecture sub-tab: "flows" | "skills" | "capabilities" (empty for other primary tabs)
 	Config            types.FlowMapConfig
 	ParseError        string
+	Bundle            json.RawMessage   // raw bundle bytes; len()>0 ↔ HasBundle
 	WizardFields      []wizardFieldView // populated for the Inputs tab
 	SelectedFlow      *types.Flow
 	SelectedSkill     *types.Skill
@@ -190,6 +191,7 @@ func (h *ConfiguratorHandler) load(r *http.Request) (configPageData, error) {
 		HasBundle:         len(version.Bundle) > 0,
 		Config:            cfg,
 		ParseError:        parseErr,
+		Bundle:            version.Bundle,
 	}, nil
 }
 
@@ -285,16 +287,12 @@ func (h *ConfiguratorHandler) Prompts(w http.ResponseWriter, r *http.Request) {
 	data.Tab = "prompts"
 
 	page := promptsPageData{configPageData: data}
-	versionID := r.PathValue("version_id")
-	// Re-fetch the version row to access Bundle (load() drops the bytes,
-	// keeping only HasBundle).
-	version, _, gerr := h.repo.GetWithAgent(r.Context(), versionID)
-	if gerr == nil && len(version.Bundle) > 0 {
+	if len(data.Bundle) > 0 {
 		var raw struct {
 			MainPrompt string            `json:"main_prompt"`
 			Skills     []skillPromptView `json:"skills"`
 		}
-		if err := json.Unmarshal(version.Bundle, &raw); err == nil {
+		if err := json.Unmarshal(data.Bundle, &raw); err == nil {
 			page.MainPrompt = raw.MainPrompt
 			page.SkillPrompts = raw.Skills
 		}

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -205,27 +205,39 @@ func (h *ConfiguratorHandler) Inputs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	data.Tab = "inputs"
-	data.WizardFields = h.buildWizardFieldViews(data.Config, data.DiscoveryFilePath)
+	data.WizardFields = h.buildWizardFieldViews(data.Config)
 	renderTemplate(w, h.inputsTmpl, "layout", data)
 }
 
-// buildWizardFieldViews maps each schema field to its current value pulled
-// from the FlowMapConfig (for text/textarea) or the agent row (for file).
+// agentLevelWizardKeys are wizard fields whose values are stored on the Agent
+// row (immutable per-agent) and therefore not shown on the per-version Inputs
+// tab — they appear on the agent detail header instead. A version cannot
+// diverge from its agent on these fields, so rendering them per-version would
+// be misleading.
+var agentLevelWizardKeys = map[string]bool{
+	"name":           true,
+	"discovery_file": true,
+}
+
+// buildWizardFieldViews maps each per-version schema field to its current
+// value pulled from the FlowMapConfig. Agent-level fields (name,
+// discovery_file) are skipped — they're rendered on the agent detail page.
 // Field order follows the schema's `order` so the layout matches the wizard.
-func (h *ConfiguratorHandler) buildWizardFieldViews(cfg types.FlowMapConfig, discoveryFilePath string) []wizardFieldView {
+func (h *ConfiguratorHandler) buildWizardFieldViews(cfg types.FlowMapConfig) []wizardFieldView {
 	if h.schema == nil {
 		return nil
 	}
 	wizardValues := map[string]string{
-		"name":            cfg.Name,
 		"scope":           cfg.Scope,
 		"should_do":       cfg.ShouldDo,
 		"should_not_do":   cfg.ShouldNotDo,
 		"business_domain": cfg.BusinessDomain,
-		"discovery_file":  discoveryFilePath,
 	}
 	out := make([]wizardFieldView, 0, len(h.schema.Wizard))
 	for _, of := range h.schema.OrderedFields() {
+		if agentLevelWizardKeys[of.Key] {
+			continue
+		}
 		out = append(out, wizardFieldView{
 			Key:   of.Key,
 			Label: of.Field.Label,

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -32,9 +32,9 @@ type ConfigStore interface {
 }
 
 type ConfiguratorHandler struct {
-	repo                                                              ConfigStore
-	schema                                                            *types.WizardSchema
-	flowsTmpl, skillsTmpl, capabilitiesTmpl, finalizeTmpl, inputsTmpl *template.Template
+	repo                                                                            ConfigStore
+	schema                                                                          *types.WizardSchema
+	flowsTmpl, skillsTmpl, capabilitiesTmpl, finalizeTmpl, inputsTmpl, promptsTmpl *template.Template
 }
 
 func NewConfiguratorHandler(repo ConfigStore, schema *types.WizardSchema, webFS fs.FS) (*ConfiguratorHandler, error) {
@@ -94,6 +94,10 @@ func NewConfiguratorHandler(repo ConfigStore, schema *types.WizardSchema, webFS 
 	if err != nil {
 		return nil, err
 	}
+	promptsTmpl, err := parse("prompts")
+	if err != nil {
+		return nil, err
+	}
 	return &ConfiguratorHandler{
 		repo:             repo,
 		schema:           schema,
@@ -102,6 +106,7 @@ func NewConfiguratorHandler(repo ConfigStore, schema *types.WizardSchema, webFS 
 		capabilitiesTmpl: capabilitiesTmpl,
 		finalizeTmpl:     finalizeTmpl,
 		inputsTmpl:       inputsTmpl,
+		promptsTmpl:      promptsTmpl,
 	}, nil
 }
 
@@ -244,6 +249,60 @@ func (h *ConfiguratorHandler) buildWizardFieldViews(cfg types.FlowMapConfig) []w
 		})
 	}
 	return out
+}
+
+// skillPromptView is the projection of a bundle skill rendered in the Prompts
+// tab. JSON tags match the bundle schema produced by aikdm.
+type skillPromptView struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Prompt      string `json:"prompt"`
+}
+
+// promptsPageData embeds configPageData and adds the prompt-specific fields.
+// Renders as an empty state when MainPrompt and SkillPrompts are both empty
+// (NULL bundle or unmarshal failure both land here).
+type promptsPageData struct {
+	configPageData
+	MainPrompt   string
+	SkillPrompts []skillPromptView
+}
+
+// Prompts renders a read-only view of the version's compiled bundle:
+// main_prompt + each skill's prompt. Malformed or NULL bundle → empty state.
+// Tools and external_actions are not shown here; they live under the
+// Architecture tab.
+func (h *ConfiguratorHandler) Prompts(w http.ResponseWriter, r *http.Request) {
+	data, err := h.load(r)
+	if err != nil {
+		if errors.Is(err, types.ErrNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	data.Tab = "prompts"
+
+	page := promptsPageData{configPageData: data}
+	versionID := r.PathValue("version_id")
+	// Re-fetch the version row to access Bundle (load() drops the bytes,
+	// keeping only HasBundle).
+	version, _, gerr := h.repo.GetWithAgent(r.Context(), versionID)
+	if gerr == nil && len(version.Bundle) > 0 {
+		var raw struct {
+			MainPrompt string            `json:"main_prompt"`
+			Skills     []skillPromptView `json:"skills"`
+		}
+		if err := json.Unmarshal(version.Bundle, &raw); err == nil {
+			page.MainPrompt = raw.MainPrompt
+			page.SkillPrompts = raw.Skills
+		}
+		// Malformed JSON falls through with both fields empty — template
+		// renders empty state.
+	}
+
+	renderTemplate(w, h.promptsTmpl, "layout", page)
 }
 
 // Index redirects /configure to the default Architecture > Flows sub-tab.

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -143,7 +143,6 @@ type configPageData struct {
 	SubTab            string // architecture sub-tab: "flows" | "skills" | "capabilities" (empty for other primary tabs)
 	Config            types.FlowMapConfig
 	ParseError        string
-	DiscoveryFilePath string
 	WizardFields      []wizardFieldView // populated for the Inputs tab
 	SelectedFlow      *types.Flow
 	SelectedSkill     *types.Skill
@@ -186,7 +185,6 @@ func (h *ConfiguratorHandler) load(r *http.Request) (configPageData, error) {
 		HasBundle:         len(version.Bundle) > 0,
 		Config:            cfg,
 		ParseError:        parseErr,
-		DiscoveryFilePath: agent.DiscoveryFilePath,
 	}, nil
 }
 

--- a/open-bbcd/internal/handler/configurator.go
+++ b/open-bbcd/internal/handler/configurator.go
@@ -113,14 +113,15 @@ var proseRelLink = regexp.MustCompile(`\.\./(skills|capabilities|flows)/([^)\s]+
 // renderMarkdown converts a prose markdown blob (from the discovery
 // skill) to HTML. Relative links into the .flow-map directory layout
 // are rewritten to the configurator routes (scoped by version_id) so
-// they actually navigate. Trusted input — prose is generated, not
+// they actually navigate. Flows / skills / capabilities live under the
+// Architecture primary tab. Trusted input — prose is generated, not
 // user-typed.
 func renderMarkdown(versionID, md string) template.HTML {
 	if md == "" {
 		return ""
 	}
 	if versionID != "" {
-		base := "/agent_versions/" + versionID + "/configure/"
+		base := "/agent_versions/" + versionID + "/configure/architecture/"
 		md = proseRelLink.ReplaceAllString(md, base+"$1/$2")
 	}
 	var buf bytes.Buffer
@@ -138,7 +139,8 @@ type configPageData struct {
 	AgentStatus       string // version's status (lives on AgentVersion now)
 	ReadOnly          bool   // true for non-INITIALIZING versions (DRAFT, TRAINING, READY, DEPLOYED)
 	HasBundle         bool   // true when this version has a generated bundle (Run is enabled)
-	Tab               string // "flows" | "skills" | "capabilities" | "inputs"
+	Tab               string // primary tab: "inputs" | "architecture" | "prompts" | "finalize"
+	SubTab            string // architecture sub-tab: "flows" | "skills" | "capabilities" (empty for other primary tabs)
 	Config            types.FlowMapConfig
 	ParseError        string
 	DiscoveryFilePath string
@@ -234,9 +236,10 @@ func (h *ConfiguratorHandler) buildWizardFieldViews(cfg types.FlowMapConfig, dis
 	return out
 }
 
-// Index redirects /agents/{id}/configure to the default Flows tab content.
+// Index redirects /configure to the default Architecture > Flows sub-tab.
 func (h *ConfiguratorHandler) Index(w http.ResponseWriter, r *http.Request) {
-	h.Flows(w, r)
+	versionID := r.PathValue("version_id")
+	http.Redirect(w, r, "/agent_versions/"+versionID+"/configure/architecture/flows", http.StatusFound)
 }
 
 func (h *ConfiguratorHandler) Flows(w http.ResponseWriter, r *http.Request) {
@@ -249,7 +252,8 @@ func (h *ConfiguratorHandler) Flows(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	data.Tab = "flows"
+	data.Tab = "architecture"
+	data.SubTab = "flows"
 	if flowID := r.PathValue("flowId"); flowID != "" {
 		for i := range data.Config.Flows {
 			if data.Config.Flows[i].ID == flowID {
@@ -275,7 +279,8 @@ func (h *ConfiguratorHandler) Skills(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	data.Tab = "skills"
+	data.Tab = "architecture"
+	data.SubTab = "skills"
 	if skillID := r.PathValue("skillId"); skillID != "" {
 		for i := range data.Config.Skills {
 			if data.Config.Skills[i].ID == skillID {
@@ -301,7 +306,8 @@ func (h *ConfiguratorHandler) Capabilities(w http.ResponseWriter, r *http.Reques
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	data.Tab = "capabilities"
+	data.Tab = "architecture"
+	data.SubTab = "capabilities"
 	if capName := r.PathValue("capName"); capName != "" {
 		for i := range data.Config.Capabilities {
 			if data.Config.Capabilities[i].Name == capName {
@@ -971,5 +977,24 @@ func (h *ConfiguratorHandler) SkillUpdate(w http.ResponseWriter, r *http.Request
 		"VersionID":    versionID,
 		"Skill":        *cur,
 		"Capabilities": cfg.Capabilities,
+	})
+}
+
+// RegisterConfiguratorRedirects mounts 301s for the pre-redesign tab URLs.
+// Bookmarks against /configure/{flows,skills,capabilities} survive; the bare
+// /configure/architecture path lands on the default Flows sub-tab.
+func RegisterConfiguratorRedirects(mux *http.ServeMux) {
+	for _, sub := range []string{"flows", "skills", "capabilities"} {
+		sub := sub
+		mux.HandleFunc("GET /agent_versions/{version_id}/configure/"+sub, func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r,
+				"/agent_versions/"+r.PathValue("version_id")+"/configure/architecture/"+sub,
+				http.StatusMovedPermanently)
+		})
+	}
+	mux.HandleFunc("GET /agent_versions/{version_id}/configure/architecture", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r,
+			"/agent_versions/"+r.PathValue("version_id")+"/configure/architecture/flows",
+			http.StatusMovedPermanently)
 	})
 }

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -958,25 +958,31 @@ func TestConfiguratorLayout_DeployButton_VisibleWhenReady(t *testing.T) {
 	}
 }
 
-func TestConfiguratorLayout_DeployButton_HiddenWhenDeployed(t *testing.T) {
+func TestConfiguratorLayout_UndeployButton_VisibleWhenDeployed(t *testing.T) {
 	body := renderConfigLayoutFixture(t, configFixture{
 		Tab: "architecture", SubTab: "flows",
 		ReadOnly: true, AgentStatus: "DEPLOYED",
 		AgentID: "a1", VersionID: "v1", AgentName: "Bot",
 	})
-	if strings.Contains(body, "deploy/confirm") {
+	if !strings.Contains(body, `hx-get="/agents/a1/undeploy/confirm"`) {
+		t.Errorf("expected Undeploy button hx-get; body:\n%s", body)
+	}
+	if strings.Contains(body, `/agents/a1/deploy/confirm`) {
 		t.Errorf("Deploy button must not render for DEPLOYED; body:\n%s", body)
 	}
 }
 
-func TestConfiguratorLayout_DeployButton_HiddenWhenDraft(t *testing.T) {
+func TestConfiguratorLayout_DeployAndUndeploy_HiddenWhenDraft(t *testing.T) {
 	body := renderConfigLayoutFixture(t, configFixture{
 		Tab: "architecture", SubTab: "flows",
 		ReadOnly: true, AgentStatus: "DRAFT",
 		AgentID: "a1", VersionID: "v1", AgentName: "Bot",
 	})
-	if strings.Contains(body, "deploy/confirm") {
+	if strings.Contains(body, `/agents/a1/deploy/confirm`) {
 		t.Errorf("Deploy button must not render for DRAFT; body:\n%s", body)
+	}
+	if strings.Contains(body, `/agents/a1/undeploy/confirm`) {
+		t.Errorf("Undeploy button must not render for DRAFT; body:\n%s", body)
 	}
 }
 

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -16,6 +16,70 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestConfiguratorRouter_OldFlowsRedirectsToArchitecture(t *testing.T) {
+	mux := http.NewServeMux()
+	handler.RegisterConfiguratorRedirects(mux)
+	versionID := "11111111-1111-1111-1111-111111111111"
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/"+versionID+"/configure/flows", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301", w.Code)
+	}
+	want := "/agent_versions/" + versionID + "/configure/architecture/flows"
+	if got := w.Header().Get("Location"); got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+func TestConfiguratorRouter_OldSkillsRedirectsToArchitecture(t *testing.T) {
+	mux := http.NewServeMux()
+	handler.RegisterConfiguratorRedirects(mux)
+	versionID := "22222222-2222-2222-2222-222222222222"
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/"+versionID+"/configure/skills", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301", w.Code)
+	}
+	want := "/agent_versions/" + versionID + "/configure/architecture/skills"
+	if got := w.Header().Get("Location"); got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+func TestConfiguratorRouter_OldCapabilitiesRedirectsToArchitecture(t *testing.T) {
+	mux := http.NewServeMux()
+	handler.RegisterConfiguratorRedirects(mux)
+	versionID := "33333333-3333-3333-3333-333333333333"
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/"+versionID+"/configure/capabilities", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301", w.Code)
+	}
+	want := "/agent_versions/" + versionID + "/configure/architecture/capabilities"
+	if got := w.Header().Get("Location"); got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
+func TestConfiguratorRouter_ArchitectureIndexRedirectsToFlows(t *testing.T) {
+	mux := http.NewServeMux()
+	handler.RegisterConfiguratorRedirects(mux)
+	versionID := "44444444-4444-4444-4444-444444444444"
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/"+versionID+"/configure/architecture", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusFound && w.Code != http.StatusMovedPermanently {
+		t.Fatalf("status = %d, want 301 or 302", w.Code)
+	}
+	want := "/agent_versions/" + versionID + "/configure/architecture/flows"
+	if got := w.Header().Get("Location"); got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}
+
 type stubConfigStore struct {
 	cfg           types.FlowMapConfig
 	getErr        error
@@ -173,10 +237,12 @@ func TestConfigurator_CapabilitiesTab_IsReadOnly(t *testing.T) {
 
 func TestConfigurator_ParseError_ShowsErrorBanner(t *testing.T) {
 	h := newConfigHandler(t, &stubConfigStore{cfg: sampleConfig(), parseErr: "missing tools-proposed.json"})
-	req := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/configure", nil)
+	// Index now 302s to /configure/architecture/flows; assert the banner on the
+	// landing handler (Flows) which is where the redirect ends up rendering.
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/abc/configure/architecture/flows", nil)
 	req.SetPathValue("version_id", "abc")
 	w := httptest.NewRecorder()
-	h.Index(w, req)
+	h.Flows(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d", w.Code)
 	}

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -978,3 +978,60 @@ func TestConfiguratorLayout_DeployButton_HiddenWhenDraft(t *testing.T) {
 		t.Errorf("Deploy button must not render for DRAFT; body:\n%s", body)
 	}
 }
+
+// TestConfigurator_InputsTab_OmitsAgentLevelFields verifies that the Inputs
+// tab renders only the 4 per-version wizard fields (scope, should_do,
+// should_not_do, business_domain). The agent-level fields `name` and
+// `discovery_file` live on the agent row and are rendered on the agent
+// detail header — showing them per-version would be misleading because a
+// version cannot diverge from its agent on those fields.
+func TestConfigurator_InputsTab_OmitsAgentLevelFields(t *testing.T) {
+	cfg := sampleConfig()
+	cfg.Scope = "in-scope text"
+	cfg.ShouldDo = "should-do text"
+	cfg.ShouldNotDo = "should-not-do text"
+	cfg.BusinessDomain = "business-domain text"
+	store := &stubConfigStore{cfg: cfg, currentStatus: "DRAFT"}
+	h := newConfigHandler(t, store)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/agent_versions/abc/configure/inputs", nil)
+	req.SetPathValue("version_id", "abc")
+	w := httptest.NewRecorder()
+	h.Inputs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+
+	// Per-version labels (from web/schemas/wizard-v1.yaml) must be present.
+	perVersionLabels := []string{
+		"Describe the scope of your agent",
+		"What should your agent do?",
+		"What should your agent never do?",
+		"Describe your platform business domain",
+	}
+	for _, label := range perVersionLabels {
+		if !strings.Contains(body, label) {
+			t.Errorf("Inputs tab missing per-version label %q", label)
+		}
+	}
+
+	// Agent-level labels must NOT appear in the Inputs tab.
+	agentLevelLabels := []string{
+		"Agent name",
+		"Upload discovery zip",
+	}
+	for _, label := range agentLevelLabels {
+		if strings.Contains(body, label) {
+			t.Errorf("Inputs tab should NOT contain agent-level label %q "+
+				"(it belongs on the agent detail header)", label)
+		}
+	}
+
+	// And the count of <dt> rows (one per WizardFields entry) must be 4.
+	if got := strings.Count(body, `class="inputs-label"`); got != 4 {
+		t.Errorf("expected 4 inputs-label rows, got %d", got)
+	}
+}

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -90,6 +90,7 @@ type stubConfigStore struct {
 	updateFn      func(cfg []byte) error
 	statusFn      func(versionID, expectedFrom, to string) error
 	currentStatus string // optional override; defaults to "INITIALIZING"
+	bundle        []byte // optional compiled bundle; rendered by the Prompts tab
 }
 
 func (s *stubConfigStore) GetFlowMapConfig(ctx context.Context, versionID string) ([]byte, string, error) {
@@ -108,7 +109,7 @@ func (s *stubConfigStore) GetWithAgent(ctx context.Context, versionID string) (*
 	// The stub uses the URL's version_id for both ids — there's only one
 	// config in this fake, and per-version calls (GetFlowMapConfig /
 	// UpdateFlowMapConfig) ignore the id anyway.
-	version := &types.AgentVersion{ID: versionID, AgentID: versionID, Status: status}
+	version := &types.AgentVersion{ID: versionID, AgentID: versionID, Status: status, Bundle: s.bundle}
 	agent := &types.Agent{ID: versionID, Name: s.cfg.Name}
 	return version, agent, nil
 }
@@ -1033,5 +1034,73 @@ func TestConfigurator_InputsTab_OmitsAgentLevelFields(t *testing.T) {
 	// And the count of <dt> rows (one per WizardFields entry) must be 4.
 	if got := strings.Count(body, `class="inputs-label"`); got != 4 {
 		t.Errorf("expected 4 inputs-label rows, got %d", got)
+	}
+}
+
+// makePromptsConfigStore returns a stubConfigStore wired for the Prompts tab:
+// a non-INITIALIZING status (so ReadOnly is true in the layout) and an
+// optional bundle payload exposed via GetWithAgent.
+func makePromptsConfigStore(status string, bundle []byte) *stubConfigStore {
+	return &stubConfigStore{
+		cfg:           sampleConfig(),
+		currentStatus: status,
+		bundle:        bundle,
+	}
+}
+
+func TestConfigurator_Prompts_RendersMainAndSkillPrompts(t *testing.T) {
+	versionID := "11111111-1111-1111-1111-111111111111"
+	bundle := []byte(`{
+		"main_prompt": "<role>Coffee bot</role>",
+		"skills": [
+			{"name":"place_order","description":"Place an order","prompt":"<role>order</role>"},
+			{"name":"check_rewards","description":"Check rewards","prompt":"<role>rewards</role>"}
+		]
+	}`)
+	h := newConfigHandler(t, makePromptsConfigStore("READY", bundle))
+
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/"+versionID+"/configure/prompts", nil)
+	req.SetPathValue("version_id", versionID)
+	w := httptest.NewRecorder()
+	h.Prompts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"&lt;role&gt;Coffee bot&lt;/role&gt;",
+		"place_order",
+		"&lt;role&gt;order&lt;/role&gt;",
+		"check_rewards",
+		"&lt;role&gt;rewards&lt;/role&gt;",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestConfigurator_Prompts_EmptyStateWhenBundleNull(t *testing.T) {
+	versionID := "22222222-2222-2222-2222-222222222222"
+	h := newConfigHandler(t, makePromptsConfigStore("DRAFT", nil))
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/"+versionID+"/configure/prompts", nil)
+	req.SetPathValue("version_id", versionID)
+	w := httptest.NewRecorder()
+	h.Prompts(w, req)
+	if !strings.Contains(w.Body.String(), "No bundle has been generated") {
+		t.Errorf("expected empty-state copy; body:\n%s", w.Body.String())
+	}
+}
+
+func TestConfigurator_Prompts_EmptyStateOnMalformedBundle(t *testing.T) {
+	versionID := "33333333-3333-3333-3333-333333333333"
+	h := newConfigHandler(t, makePromptsConfigStore("READY", []byte("not json")))
+	req := httptest.NewRequest(http.MethodGet, "/agent_versions/"+versionID+"/configure/prompts", nil)
+	req.SetPathValue("version_id", versionID)
+	w := httptest.NewRecorder()
+	h.Prompts(w, req)
+	if !strings.Contains(w.Body.String(), "No bundle has been generated") {
+		t.Errorf("expected empty-state copy on malformed bundle; body:\n%s", w.Body.String())
 	}
 }

--- a/open-bbcd/internal/handler/configurator_test.go
+++ b/open-bbcd/internal/handler/configurator_test.go
@@ -1,9 +1,11 @@
 package handler_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -887,5 +889,92 @@ func TestConfigurator_DownloadYAML_CleanDropsExcludedAndOrphans(t *testing.T) {
 	if len(clean.Skills) != len(cfg.Skills) {
 		t.Errorf("clean export should not touch skills, got %d (want %d)",
 			len(clean.Skills), len(cfg.Skills))
+	}
+}
+
+// configFixture is the minimum field-set the configurator's layout.html
+// reads. It mirrors the shape of (unexported) configPageData; the template
+// engine is duck-typed so a local struct works fine for header-rendering
+// tests that don't exercise tab content.
+type configFixture struct {
+	Active      string
+	Tab         string
+	SubTab      string
+	ReadOnly    bool
+	HasBundle   bool
+	AgentID     string
+	AgentName   string
+	AgentStatus string
+	VersionID   string
+	ParseError  string
+}
+
+// renderConfigLayoutFixture parses the real layout.html + a stub tab_content
+// block and returns the rendered HTML. It registers only the FuncMap entries
+// layout.html actually references (statusClass on the status pill); the
+// configurator's other helpers belong to per-tab templates that the stub
+// replaces.
+func renderConfigLayoutFixture(t *testing.T, f configFixture) string {
+	t.Helper()
+	statusClass := func(status string) string {
+		switch status {
+		case "DEPLOYED":
+			return "deployed"
+		case "READY":
+			return "ready"
+		case "TRAINING":
+			return "training"
+		case "INITIALIZING":
+			return "initializing"
+		default:
+			return "draft"
+		}
+	}
+	tmpl := template.Must(template.New("").Funcs(template.FuncMap{
+		"statusClass": statusClass,
+	}).ParseFiles(
+		"../../web/templates/layout.html",
+		"../../web/templates/configurator/layout.html",
+	))
+	// Stub tab_content so layout.html's {{template "tab_content" .}} works
+	// without parsing the per-tab templates (which pull in other funcs).
+	template.Must(tmpl.Parse(`{{define "tab_content"}}<div></div>{{end}}`))
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "layout", f); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	return buf.String()
+}
+
+func TestConfiguratorLayout_DeployButton_VisibleWhenReady(t *testing.T) {
+	body := renderConfigLayoutFixture(t, configFixture{
+		Tab: "architecture", SubTab: "flows",
+		ReadOnly: true, AgentStatus: "READY",
+		AgentID: "a1", VersionID: "v1", AgentName: "Bot",
+	})
+	if !strings.Contains(body, `hx-get="/agents/a1/deploy/confirm?version_id=v1"`) {
+		t.Errorf("expected Deploy button hx-get; body:\n%s", body)
+	}
+}
+
+func TestConfiguratorLayout_DeployButton_HiddenWhenDeployed(t *testing.T) {
+	body := renderConfigLayoutFixture(t, configFixture{
+		Tab: "architecture", SubTab: "flows",
+		ReadOnly: true, AgentStatus: "DEPLOYED",
+		AgentID: "a1", VersionID: "v1", AgentName: "Bot",
+	})
+	if strings.Contains(body, "deploy/confirm") {
+		t.Errorf("Deploy button must not render for DEPLOYED; body:\n%s", body)
+	}
+}
+
+func TestConfiguratorLayout_DeployButton_HiddenWhenDraft(t *testing.T) {
+	body := renderConfigLayoutFixture(t, configFixture{
+		Tab: "architecture", SubTab: "flows",
+		ReadOnly: true, AgentStatus: "DRAFT",
+		AgentID: "a1", VersionID: "v1", AgentName: "Bot",
+	})
+	if strings.Contains(body, "deploy/confirm") {
+		t.Errorf("Deploy button must not render for DRAFT; body:\n%s", body)
 	}
 }

--- a/open-bbcd/internal/handler/ui.go
+++ b/open-bbcd/internal/handler/ui.go
@@ -351,7 +351,10 @@ func (h *UIHandler) DiscoveryDownload(w http.ResponseWriter, r *http.Request) {
 	}
 	defer rc.Close()
 	w.Header().Set("Content-Type", "application/zip")
-	w.Header().Set("Content-Disposition", `attachment; filename="`+agent.DiscoveryFilePath+`"`)
+	// Filename derives from agent.ID (always a UUID) rather than the
+	// discovery_file_path column — keeps header-injection-safe even if the
+	// path column ever holds untrusted strings.
+	w.Header().Set("Content-Disposition", `attachment; filename="`+agent.ID+`.zip"`)
 	if _, err := io.Copy(w, rc); err != nil {
 		h.logger.Warn("discovery download copy failed", slog.Any("error", err))
 	}

--- a/open-bbcd/internal/handler/ui.go
+++ b/open-bbcd/internal/handler/ui.go
@@ -3,7 +3,9 @@ package handler
 import (
 	"bytes"
 	"context"
+	"errors"
 	"html/template"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -11,6 +13,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/DACdigital/OpenBBC/open-bbcd/internal/storage"
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
 )
 
@@ -22,6 +25,7 @@ type GroupedAgentRepository interface {
 type UIHandler struct {
 	agentRepo         GroupedAgentRepository
 	versions          DeployVersionRepository
+	storage           storage.Storage
 	schema            *types.WizardSchema
 	logger            *slog.Logger
 	agentsTmpl        *template.Template
@@ -47,7 +51,7 @@ func statusClass(status string) string {
 	}
 }
 
-func NewUIHandler(agentRepo GroupedAgentRepository, versions DeployVersionRepository, schema *types.WizardSchema, webFS fs.FS, logger *slog.Logger) (*UIHandler, error) {
+func NewUIHandler(agentRepo GroupedAgentRepository, versions DeployVersionRepository, store storage.Storage, schema *types.WizardSchema, webFS fs.FS, logger *slog.Logger) (*UIHandler, error) {
 	funcs := template.FuncMap{
 		"statusClass": statusClass,
 		"add":         func(a, b int) int { return a + b },
@@ -102,6 +106,7 @@ func NewUIHandler(agentRepo GroupedAgentRepository, versions DeployVersionReposi
 	return &UIHandler{
 		agentRepo:         agentRepo,
 		versions:          versions,
+		storage:           store,
 		schema:            schema,
 		logger:            logger,
 		agentsTmpl:        agentsTmpl,
@@ -310,4 +315,44 @@ func (u *UIHandler) UndeployConfirm(w http.ResponseWriter, r *http.Request) {
 		AgentID string
 		Version *types.AgentVersion
 	}{agentID, cur})
+}
+
+// DiscoveryDownload streams the discovery zip referenced by the agent's
+// discovery_file_path. Returns 404 when the agent does not exist, has no
+// discovery_file_path, or the underlying blob is missing.
+func (h *UIHandler) DiscoveryDownload(w http.ResponseWriter, r *http.Request) {
+	agentID := r.PathValue("agent_id")
+	agent, err := h.agentRepo.GetByID(r.Context(), agentID)
+	if err != nil {
+		if errors.Is(err, types.ErrNotFound) {
+			http.NotFound(w, r)
+			return
+		}
+		Error(w, err)
+		return
+	}
+	if agent.DiscoveryFilePath == "" {
+		http.NotFound(w, r)
+		return
+	}
+	rc, err := h.storage.Open(r.Context(), agent.DiscoveryFilePath)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			h.logger.Info("discovery file missing on disk",
+				slog.String("agent_id", agentID),
+				slog.String("key", agent.DiscoveryFilePath),
+			)
+			http.NotFound(w, r)
+			return
+		}
+		h.logger.Error("storage.Open", slog.Any("error", err))
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	defer rc.Close()
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+agent.DiscoveryFilePath+`"`)
+	if _, err := io.Copy(w, rc); err != nil {
+		h.logger.Warn("discovery download copy failed", slog.Any("error", err))
+	}
 }

--- a/open-bbcd/internal/handler/ui.go
+++ b/open-bbcd/internal/handler/ui.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
 )
@@ -141,18 +142,39 @@ func (h *UIHandler) AgentsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if agentID := r.URL.Query().Get("agent"); agentID != "" {
-		for _, group := range groups {
-			if group.AgentID == agentID {
-				renderTemplate(w, h.agentVersionsTmpl, "layout", agentVersionsPageData{
-					Active:   "agents",
-					AgentID:  group.AgentID,
-					Name:     group.Name,
-					Versions: group.Versions,
-				})
-				return
+		var group *types.AgentGroup
+		for i := range groups {
+			if groups[i].AgentID == agentID {
+				group = &groups[i]
+				break
 			}
 		}
-		http.NotFound(w, r)
+		if group == nil {
+			http.NotFound(w, r)
+			return
+		}
+		agent, err := h.agentRepo.GetByID(r.Context(), agentID)
+		if err != nil {
+			Error(w, err)
+			return
+		}
+		data := agentVersionsPageData{
+			Active:            "agents",
+			AgentID:           group.AgentID,
+			Name:              group.Name,
+			Description:       agent.Description,
+			DiscoveryFilePath: agent.DiscoveryFilePath,
+			CreatedAt:         agent.CreatedAt,
+			Versions:          group.Versions,
+		}
+		for _, v := range group.Versions {
+			if v.Version != nil && v.Version.Status == "DEPLOYED" {
+				data.CurrentDeployedVersionNum = v.VersionNum
+				data.CurrentDeployedVersionID = v.Version.ID
+				break
+			}
+		}
+		renderTemplate(w, h.agentVersionsTmpl, "layout", data)
 		return
 	}
 
@@ -160,10 +182,15 @@ func (h *UIHandler) AgentsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 type agentVersionsPageData struct {
-	Active   string
-	AgentID  string
-	Name     string
-	Versions []types.AgentVersionListItem
+	Active                    string
+	AgentID                   string
+	Name                      string
+	Description               string
+	DiscoveryFilePath         string
+	CreatedAt                 time.Time
+	CurrentDeployedVersionNum int    // 0 if no version is deployed
+	CurrentDeployedVersionID  string // empty if none
+	Versions                  []types.AgentVersionListItem
 }
 
 type wizardPageData struct {

--- a/open-bbcd/internal/handler/ui.go
+++ b/open-bbcd/internal/handler/ui.go
@@ -167,6 +167,8 @@ func (h *UIHandler) AgentsPage(w http.ResponseWriter, r *http.Request) {
 			CreatedAt:         agent.CreatedAt,
 			Versions:          group.Versions,
 		}
+		// Versions are returned newest-first by ListGrouped; at most one is DEPLOYED
+		// at a time (enforced by DB partial unique index), so first match wins.
 		for _, v := range group.Versions {
 			if v.Version != nil && v.Version.Status == "DEPLOYED" {
 				data.CurrentDeployedVersionNum = v.VersionNum

--- a/open-bbcd/internal/handler/ui_test.go
+++ b/open-bbcd/internal/handler/ui_test.go
@@ -3,10 +3,12 @@ package handler
 import (
 	"context"
 	"html/template"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
 	"gopkg.in/yaml.v3"
@@ -82,5 +84,105 @@ func TestUIHandler_WizardStep_AccumulatesValues(t *testing.T) {
 	body := w.Body.String()
 	if !strings.Contains(body, `name="name"`) || !strings.Contains(body, `value="TestAgent"`) {
 		t.Errorf("expected hidden input for name=TestAgent in body:\n%s", body)
+	}
+}
+
+type mockGroupedAgentRepo2 struct {
+	listGrouped func(ctx context.Context) ([]types.AgentGroup, error)
+	getByID     func(ctx context.Context, id string) (*types.Agent, error)
+}
+
+func (m *mockGroupedAgentRepo2) ListGrouped(ctx context.Context) ([]types.AgentGroup, error) {
+	return m.listGrouped(ctx)
+}
+func (m *mockGroupedAgentRepo2) GetByID(ctx context.Context, id string) (*types.Agent, error) {
+	return m.getByID(ctx, id)
+}
+
+func mustParseAgentVersionsTmpl(t *testing.T) *template.Template {
+	t.Helper()
+	const layout = `{{define "layout"}}{{template "content" .}}{{end}}`
+	const content = `{{define "content"}}` +
+		`<h1>{{.Name}}</h1>` +
+		`<p class="desc">{{.Description}}</p>` +
+		`<p class="path">{{.DiscoveryFilePath}}</p>` +
+		`<p class="deployed">{{if .CurrentDeployedVersionNum}}v{{.CurrentDeployedVersionNum}}{{else}}—{{end}}</p>` +
+		`{{range .Versions}}<div class="v">v{{.VersionNum}}:{{.Version.Status}}</div>{{end}}` +
+		`{{end}}`
+	return template.Must(template.New("").Funcs(template.FuncMap{
+		"statusClass": statusClass,
+	}).Parse(layout + content))
+}
+
+func TestUIHandler_AgentDetail_PopulatesHeader(t *testing.T) {
+	createdAt := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	agentID := "11111111-1111-1111-1111-111111111111"
+	agent := &types.Agent{
+		ID:                agentID,
+		Name:              "Coffee Bot",
+		Description:       "Shop assistant",
+		DiscoveryFilePath: "coffee.zip",
+		CreatedAt:         createdAt,
+	}
+	groups := []types.AgentGroup{{
+		AgentID: agentID,
+		Name:    "Coffee Bot",
+		Versions: []types.AgentVersionListItem{
+			{VersionNum: 2, Version: &types.AgentVersion{ID: "v2", Status: "DEPLOYED"}},
+			{VersionNum: 1, Version: &types.AgentVersion{ID: "v1", Status: "READY"}},
+		},
+	}}
+	h := &UIHandler{
+		agentRepo: &mockGroupedAgentRepo2{
+			listGrouped: func(ctx context.Context) ([]types.AgentGroup, error) { return groups, nil },
+			getByID:     func(ctx context.Context, id string) (*types.Agent, error) { return agent, nil },
+		},
+		agentVersionsTmpl: mustParseAgentVersionsTmpl(t),
+		logger:            slog.Default(),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/agents/ui?agent="+agentID, nil)
+	w := httptest.NewRecorder()
+	h.AgentsPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{
+		"Coffee Bot",
+		"Shop assistant",
+		"coffee.zip",
+		`<p class="deployed">v2</p>`,
+		`<div class="v">v2:DEPLOYED</div>`,
+		`<div class="v">v1:READY</div>`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\n--- body ---\n%s", want, body)
+		}
+	}
+}
+
+func TestUIHandler_AgentDetail_NoneDeployed(t *testing.T) {
+	agentID := "22222222-2222-2222-2222-222222222222"
+	agent := &types.Agent{ID: agentID, Name: "X", DiscoveryFilePath: "x.zip"}
+	groups := []types.AgentGroup{{
+		AgentID: agentID, Name: "X",
+		Versions: []types.AgentVersionListItem{
+			{VersionNum: 1, Version: &types.AgentVersion{ID: "v1", Status: "READY"}},
+		},
+	}}
+	h := &UIHandler{
+		agentRepo: &mockGroupedAgentRepo2{
+			listGrouped: func(ctx context.Context) ([]types.AgentGroup, error) { return groups, nil },
+			getByID:     func(ctx context.Context, id string) (*types.Agent, error) { return agent, nil },
+		},
+		agentVersionsTmpl: mustParseAgentVersionsTmpl(t),
+		logger:            slog.Default(),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/agents/ui?agent="+agentID, nil)
+	w := httptest.NewRecorder()
+	h.AgentsPage(w, req)
+	if !strings.Contains(w.Body.String(), `<p class="deployed">—</p>`) {
+		t.Errorf("expected em-dash for no-deploy:\n%s", w.Body.String())
 	}
 }

--- a/open-bbcd/internal/handler/ui_test.go
+++ b/open-bbcd/internal/handler/ui_test.go
@@ -261,7 +261,7 @@ func TestUIHandler_DiscoveryDownload_StreamsZip(t *testing.T) {
 	if w.Header().Get("Content-Type") != "application/zip" {
 		t.Errorf("content-type = %q", w.Header().Get("Content-Type"))
 	}
-	if got := w.Header().Get("Content-Disposition"); !strings.Contains(got, `attachment; filename="abc.zip"`) {
+	if got := w.Header().Get("Content-Disposition"); !strings.Contains(got, `attachment; filename="`+agentID+`.zip"`) {
 		t.Errorf("content-disposition = %q", got)
 	}
 }

--- a/open-bbcd/internal/handler/ui_test.go
+++ b/open-bbcd/internal/handler/ui_test.go
@@ -1,8 +1,10 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"html/template"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DACdigital/OpenBBC/open-bbcd/internal/storage"
 	"github.com/DACdigital/OpenBBC/open-bbcd/internal/types"
 	"gopkg.in/yaml.v3"
 )
@@ -216,5 +219,106 @@ func TestUIHandler_AgentDetail_NoneDeployed(t *testing.T) {
 	h.AgentsPage(w, req)
 	if !strings.Contains(w.Body.String(), `<p class="deployed">—</p>`) {
 		t.Errorf("expected em-dash for no-deploy:\n%s", w.Body.String())
+	}
+}
+
+type stubStorage struct {
+	openFn func(ctx context.Context, key string) (io.ReadCloser, error)
+}
+
+func (s *stubStorage) Put(ctx context.Context, key string, r io.Reader) error { return nil }
+func (s *stubStorage) Open(ctx context.Context, key string) (io.ReadCloser, error) {
+	return s.openFn(ctx, key)
+}
+
+func TestUIHandler_DiscoveryDownload_StreamsZip(t *testing.T) {
+	agentID := "33333333-3333-3333-3333-333333333333"
+	agent := &types.Agent{ID: agentID, Name: "X", DiscoveryFilePath: "abc.zip"}
+	body := []byte("PK\x03\x04 fake zip")
+	h := &UIHandler{
+		agentRepo: &mockGroupedAgentRepo{
+			getByID: func(ctx context.Context, id string) (*types.Agent, error) { return agent, nil },
+		},
+		storage: &stubStorage{openFn: func(ctx context.Context, key string) (io.ReadCloser, error) {
+			if key != "abc.zip" {
+				t.Fatalf("Open called with %q, want abc.zip", key)
+			}
+			return io.NopCloser(bytes.NewReader(body)), nil
+		}},
+		logger: slog.Default(),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/agents/"+agentID+"/discovery", nil)
+	req.SetPathValue("agent_id", agentID)
+	w := httptest.NewRecorder()
+	h.DiscoveryDownload(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := w.Body.Bytes(); !bytes.Equal(got, body) {
+		t.Errorf("body mismatch: got %q", got)
+	}
+	if w.Header().Get("Content-Type") != "application/zip" {
+		t.Errorf("content-type = %q", w.Header().Get("Content-Type"))
+	}
+	if got := w.Header().Get("Content-Disposition"); !strings.Contains(got, `attachment; filename="abc.zip"`) {
+		t.Errorf("content-disposition = %q", got)
+	}
+}
+
+func TestUIHandler_DiscoveryDownload_AgentNotFound(t *testing.T) {
+	h := &UIHandler{
+		agentRepo: &mockGroupedAgentRepo{
+			getByID: func(ctx context.Context, id string) (*types.Agent, error) {
+				return nil, types.ErrNotFound
+			},
+		},
+		logger: slog.Default(),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/agents/missing/discovery", nil)
+	req.SetPathValue("agent_id", "missing")
+	w := httptest.NewRecorder()
+	h.DiscoveryDownload(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestUIHandler_DiscoveryDownload_NoDiscoveryFile(t *testing.T) {
+	agentID := "44444444-4444-4444-4444-444444444444"
+	agent := &types.Agent{ID: agentID, Name: "X", DiscoveryFilePath: ""}
+	h := &UIHandler{
+		agentRepo: &mockGroupedAgentRepo{
+			getByID: func(ctx context.Context, id string) (*types.Agent, error) { return agent, nil },
+		},
+		logger: slog.Default(),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/agents/"+agentID+"/discovery", nil)
+	req.SetPathValue("agent_id", agentID)
+	w := httptest.NewRecorder()
+	h.DiscoveryDownload(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestUIHandler_DiscoveryDownload_FileMissingOnDisk(t *testing.T) {
+	agentID := "55555555-5555-5555-5555-555555555555"
+	agent := &types.Agent{ID: agentID, Name: "X", DiscoveryFilePath: "abc.zip"}
+	h := &UIHandler{
+		agentRepo: &mockGroupedAgentRepo{
+			getByID: func(ctx context.Context, id string) (*types.Agent, error) { return agent, nil },
+		},
+		storage: &stubStorage{openFn: func(ctx context.Context, key string) (io.ReadCloser, error) {
+			return nil, storage.ErrNotFound
+		}},
+		logger: slog.Default(),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/agents/"+agentID+"/discovery", nil)
+	req.SetPathValue("agent_id", agentID)
+	w := httptest.NewRecorder()
+	h.DiscoveryDownload(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
 	}
 }

--- a/open-bbcd/internal/handler/ui_test.go
+++ b/open-bbcd/internal/handler/ui_test.go
@@ -154,6 +154,46 @@ func TestUIHandler_AgentDetail_PopulatesHeader(t *testing.T) {
 	}
 }
 
+func TestUIHandler_AgentDetail_RealTemplateRenders(t *testing.T) {
+	agentID := "00000000-0000-0000-0000-000000000000"
+	agent := &types.Agent{ID: agentID, Name: "Bot", Description: "Desc", DiscoveryFilePath: "bot.zip", CreatedAt: time.Now()}
+	groups := []types.AgentGroup{{
+		AgentID: agentID, Name: "Bot",
+		Versions: []types.AgentVersionListItem{
+			{VersionNum: 1, Version: &types.AgentVersion{ID: "v1", Status: "READY", CreatedAt: time.Now()}},
+		},
+	}}
+	tmpl, err := template.New("").Funcs(template.FuncMap{
+		"statusClass": statusClass,
+		"add":         func(a, b int) int { return a + b },
+		"sub":         func(a, b int) int { return a - b },
+		"urlEncode":   func(s string) string { return s },
+	}).ParseFiles("../../web/templates/layout.html", "../../web/templates/agent-versions.html")
+	if err != nil {
+		t.Fatalf("ParseFiles: %v", err)
+	}
+	h := &UIHandler{
+		agentRepo: &mockGroupedAgentRepo{
+			listGrouped: func(ctx context.Context) ([]types.AgentGroup, error) { return groups, nil },
+			getByID:     func(ctx context.Context, id string) (*types.Agent, error) { return agent, nil },
+		},
+		agentVersionsTmpl: tmpl,
+		logger:            slog.Default(),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/agents/ui?agent="+agentID, nil)
+	w := httptest.NewRecorder()
+	h.AgentsPage(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	for _, want := range []string{"agent-header-card", "Bot", "Desc", "bot.zip", `v1`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("real template missing %q", want)
+		}
+	}
+}
+
 func TestUIHandler_AgentDetail_NoneDeployed(t *testing.T) {
 	agentID := "22222222-2222-2222-2222-222222222222"
 	agent := &types.Agent{ID: agentID, Name: "X", DiscoveryFilePath: "x.zip"}

--- a/open-bbcd/internal/handler/ui_test.go
+++ b/open-bbcd/internal/handler/ui_test.go
@@ -190,7 +190,7 @@ func TestUIHandler_AgentDetail_RealTemplateRenders(t *testing.T) {
 		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
 	}
 	body := w.Body.String()
-	for _, want := range []string{"agent-header-card", "Bot", "Desc", "bot.zip", `v1`} {
+	for _, want := range []string{"agent-meta", "Bot", "Desc", "bot.zip", `v1`} {
 		if !strings.Contains(body, want) {
 			t.Errorf("real template missing %q", want)
 		}

--- a/open-bbcd/internal/handler/ui_test.go
+++ b/open-bbcd/internal/handler/ui_test.go
@@ -29,14 +29,6 @@ wizard:
     order: 2
 `
 
-type mockGroupedAgentRepo struct {
-	listGroupedFn func(ctx context.Context) ([]types.AgentGroup, error)
-}
-
-func (m *mockGroupedAgentRepo) ListGrouped(ctx context.Context) ([]types.AgentGroup, error) {
-	return m.listGroupedFn(ctx)
-}
-
 func mustParseStepTmpl(t *testing.T) *template.Template {
 	t.Helper()
 	const src = `{{define "step"}}{{range $k,$v := .Values}}<input name="{{$k}}" value="{{$v}}">{{end}}{{.Field.Field.Label}}{{end}}`
@@ -87,15 +79,15 @@ func TestUIHandler_WizardStep_AccumulatesValues(t *testing.T) {
 	}
 }
 
-type mockGroupedAgentRepo2 struct {
+type mockGroupedAgentRepo struct {
 	listGrouped func(ctx context.Context) ([]types.AgentGroup, error)
 	getByID     func(ctx context.Context, id string) (*types.Agent, error)
 }
 
-func (m *mockGroupedAgentRepo2) ListGrouped(ctx context.Context) ([]types.AgentGroup, error) {
+func (m *mockGroupedAgentRepo) ListGrouped(ctx context.Context) ([]types.AgentGroup, error) {
 	return m.listGrouped(ctx)
 }
-func (m *mockGroupedAgentRepo2) GetByID(ctx context.Context, id string) (*types.Agent, error) {
+func (m *mockGroupedAgentRepo) GetByID(ctx context.Context, id string) (*types.Agent, error) {
 	return m.getByID(ctx, id)
 }
 
@@ -133,7 +125,7 @@ func TestUIHandler_AgentDetail_PopulatesHeader(t *testing.T) {
 		},
 	}}
 	h := &UIHandler{
-		agentRepo: &mockGroupedAgentRepo2{
+		agentRepo: &mockGroupedAgentRepo{
 			listGrouped: func(ctx context.Context) ([]types.AgentGroup, error) { return groups, nil },
 			getByID:     func(ctx context.Context, id string) (*types.Agent, error) { return agent, nil },
 		},
@@ -172,7 +164,7 @@ func TestUIHandler_AgentDetail_NoneDeployed(t *testing.T) {
 		},
 	}}
 	h := &UIHandler{
-		agentRepo: &mockGroupedAgentRepo2{
+		agentRepo: &mockGroupedAgentRepo{
 			listGrouped: func(ctx context.Context) ([]types.AgentGroup, error) { return groups, nil },
 			getByID:     func(ctx context.Context, id string) (*types.Agent, error) { return agent, nil },
 		},

--- a/open-bbcd/internal/handler/wizard_test.go
+++ b/open-bbcd/internal/handler/wizard_test.go
@@ -63,6 +63,12 @@ func (m *mockStorage) Put(ctx context.Context, key string, r io.Reader) error {
 	return nil
 }
 
+// Open is unused in wizard tests; included so mockStorage satisfies the
+// storage.Storage interface.
+func (m *mockStorage) Open(ctx context.Context, key string) (io.ReadCloser, error) {
+	return nil, errors.New("mockStorage.Open: not implemented")
+}
+
 var _ storage.Storage = (*mockStorage)(nil)
 
 const testMaxUploadBytes = 50 << 20 // 50 MB

--- a/open-bbcd/internal/storage/storage.go
+++ b/open-bbcd/internal/storage/storage.go
@@ -1,20 +1,33 @@
-// Package storage abstracts blob writes for uploaded artifacts.
+// Package storage abstracts blob reads and writes for uploaded artifacts.
 package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-// Storage writes blobs identified by a relative key.
+// ErrNotFound is returned by Open when the key does not exist.
+var ErrNotFound = errors.New("storage: key not found")
+
+// ErrInvalidKey is returned when the key contains path separators, is empty,
+// or otherwise resolves outside the storage root.
+var ErrInvalidKey = errors.New("storage: invalid key")
+
+// Storage reads and writes blobs identified by a relative key.
 type Storage interface {
 	// Put writes the data at the given relative key. Implementations must be
 	// atomic with respect to readers — partial writes must not be observable
 	// under the final key.
 	Put(ctx context.Context, key string, r io.Reader) error
+	// Open returns a ReadCloser for the blob at key. Callers must Close.
+	// Returns ErrNotFound if the key does not exist and ErrInvalidKey for
+	// malformed keys.
+	Open(ctx context.Context, key string) (io.ReadCloser, error)
 }
 
 // LocalDisk is a Storage backed by a directory on the local filesystem.
@@ -29,6 +42,19 @@ func NewLocalDisk(root string) (*LocalDisk, error) {
 		return nil, fmt.Errorf("storage: mkdir %q: %w", root, err)
 	}
 	return &LocalDisk{Root: root}, nil
+}
+
+// validateKey rejects empty keys, absolute paths, and anything containing a
+// separator. Storage keys are intentionally flat — callers must namespace via
+// the key contents (e.g. UUIDs), not subdirectories.
+func validateKey(key string) error {
+	if key == "" {
+		return ErrInvalidKey
+	}
+	if strings.ContainsAny(key, `/\`) || strings.Contains(key, "..") {
+		return ErrInvalidKey
+	}
+	return nil
 }
 
 // Put writes r to Root/<key+".tmp">, fsyncs, then renames to Root/<key>.
@@ -63,4 +89,20 @@ func (s *LocalDisk) Put(ctx context.Context, key string, r io.Reader) error {
 		return fmt.Errorf("storage: rename: %w", err)
 	}
 	return nil
+}
+
+// Open returns a ReadCloser for the blob at key. Caller must Close. Returns
+// ErrNotFound if no such key exists, ErrInvalidKey for malformed keys.
+func (s *LocalDisk) Open(ctx context.Context, key string) (io.ReadCloser, error) {
+	if err := validateKey(key); err != nil {
+		return nil, err
+	}
+	f, err := os.Open(filepath.Join(s.Root, key))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("storage: open: %w", err)
+	}
+	return f, nil
 }

--- a/open-bbcd/internal/storage/storage_test.go
+++ b/open-bbcd/internal/storage/storage_test.go
@@ -3,8 +3,11 @@ package storage
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -69,5 +72,54 @@ func TestLocalDisk_PutAtomic_NoTmpVisibleAtFinalKey(t *testing.T) {
 	// No leftover .tmp at the final key.
 	if _, err := os.Stat(final + ".tmp"); !os.IsNotExist(err) {
 		t.Errorf(".tmp file should not remain: %v", err)
+	}
+}
+
+func TestLocalDisk_OpenReturnsContents(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewLocalDisk(dir)
+	if err != nil {
+		t.Fatalf("NewLocalDisk: %v", err)
+	}
+	if err := s.Put(t.Context(), "abc.zip", strings.NewReader("hello")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	rc, err := s.Open(t.Context(), "abc.zip")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer rc.Close()
+	b, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(b) != "hello" {
+		t.Errorf("contents = %q, want %q", string(b), "hello")
+	}
+}
+
+func TestLocalDisk_OpenMissingKeyReturnsErrNotFound(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewLocalDisk(dir)
+	if err != nil {
+		t.Fatalf("NewLocalDisk: %v", err)
+	}
+	_, err = s.Open(t.Context(), "missing.zip")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestLocalDisk_OpenRejectsPathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewLocalDisk(dir)
+	if err != nil {
+		t.Fatalf("NewLocalDisk: %v", err)
+	}
+	for _, bad := range []string{"../escape", "sub/dir/key", "/abs/path", ""} {
+		_, err := s.Open(t.Context(), bad)
+		if !errors.Is(err, ErrInvalidKey) {
+			t.Errorf("key %q: err = %v, want ErrInvalidKey", bad, err)
+		}
 	}
 }

--- a/open-bbcd/web/static/configurator.css
+++ b/open-bbcd/web/static/configurator.css
@@ -61,6 +61,29 @@
 
 .config-spacer { flex: 1; }
 
+.config-subtabs {
+  display: flex;
+  gap: 4px;
+  margin: 8px 0 16px 0;
+  border-bottom: 1px solid #30363d;
+}
+
+.config-subtab {
+  padding: 6px 12px;
+  font-size: 13px;
+  color: #c9d1d9;
+  border-bottom: 2px solid transparent;
+  text-decoration: none;
+  margin-bottom: -1px;
+}
+
+.config-subtab.active {
+  color: #58a6ff;
+  border-bottom-color: #58a6ff;
+}
+
+.config-subtab:hover { color: #f0f6fc; }
+
 .config-actions { display: flex; gap: 8px; align-items: center; }
 .config-actions .btn-primary,
 .config-actions .btn-secondary { padding: 6px 14px; font-size: 13px; }

--- a/open-bbcd/web/static/configurator.css
+++ b/open-bbcd/web/static/configurator.css
@@ -141,6 +141,45 @@
 .inputs-value.is-file code { color: #79c0ff; background: transparent; padding: 0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
 .inputs-empty { color: #6e7681; font-style: italic; }
 
+/* Prompts tab — read-only display of the compiled bundle's main_prompt and
+   per-skill prompts. Tools/external_actions are intentionally not rendered
+   here; they live under Architecture. */
+.prompts-tab { max-width: 980px; padding: 8px 4px 24px; }
+.prompts-tab .empty-state { color: #8b949e; font-style: italic; }
+.prompt-block { margin-bottom: 24px; }
+.prompt-block h2,
+.prompt-skills h2 {
+  margin: 0 0 8px 0;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: #8b949e;
+  font-weight: 600;
+}
+.prompt-pre {
+  background: #0d1117;
+  padding: 12px 14px;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  overflow-x: auto;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  color: #e6edf3;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  margin: 0;
+}
+.prompt-skills { display: flex; flex-direction: column; gap: 6px; }
+.prompt-skill {
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 8px 12px;
+  background: #161b22;
+}
+.prompt-skill summary { cursor: pointer; color: #e6edf3; }
+.prompt-skill[open] { background: #1c2230; }
+.prompt-skill[open] summary { margin-bottom: 8px; }
+
 /* Read-only preview tweaks. */
 .config-readonly .config-list-row-toggle { cursor: not-allowed; opacity: .5; }
 .config-readonly .config-list-row-toggle:hover { box-shadow: none; }

--- a/open-bbcd/web/static/openbbc-flow.js
+++ b/open-bbcd/web/static/openbbc-flow.js
@@ -518,7 +518,7 @@
     async function doSave() {
       const next = currentWorkflow();
       const mermaid = OpenBBCFlow.serializeMermaid(next);
-      const url = `/agent_versions/${root.dataset.versionId}/configure/flows/${root.dataset.flowId}/workflow`;
+      const url = `/agent_versions/${root.dataset.versionId}/configure/architecture/flows/${root.dataset.flowId}/workflow`;
       try {
         const res = await fetch(url, {
           method: "POST",

--- a/open-bbcd/web/templates/agent-versions.html
+++ b/open-bbcd/web/templates/agent-versions.html
@@ -10,7 +10,7 @@
            class="btn-secondary">Download discovery</a>
       {{end}}
       {{if .CurrentDeployedVersionID}}
-        <button class="btn-small btn-danger"
+        <button class="btn-secondary btn-danger"
                 hx-get="/agents/{{.AgentID}}/undeploy/confirm"
                 hx-target="body" hx-swap="beforeend">Undeploy</button>
       {{end}}

--- a/open-bbcd/web/templates/agent-versions.html
+++ b/open-bbcd/web/templates/agent-versions.html
@@ -1,38 +1,56 @@
 {{define "content"}}
 <a href="/agents/ui" class="wizard-back">← Back to Agents</a>
-<div class="page-header">
-  <h1>{{.Name}}</h1>
-</div>
 
+<section class="agent-header-card">
+  <header class="agent-header-top">
+    <h1>{{.Name}}</h1>
+    <div class="agent-header-actions">
+      {{if .DiscoveryFilePath}}
+        <a href="/agents/{{.AgentID}}/discovery"
+           class="btn-secondary">Download discovery</a>
+      {{end}}
+      {{if .CurrentDeployedVersionID}}
+        <button class="btn-small btn-danger"
+                hx-get="/agents/{{.AgentID}}/undeploy/confirm"
+                hx-target="body" hx-swap="beforeend">Undeploy</button>
+      {{end}}
+    </div>
+  </header>
+  {{if .Description}}<p class="agent-header-desc">{{.Description}}</p>{{end}}
+  <dl class="agent-header-meta">
+    <div><dt>Created</dt><dd>{{.CreatedAt.Format "Jan 2, 2006"}}</dd></div>
+    {{if .DiscoveryFilePath}}<div><dt>Discovery file</dt><dd><code>{{.DiscoveryFilePath}}</code></dd></div>{{end}}
+    <div>
+      <dt>Currently deployed</dt>
+      <dd>
+        {{if .CurrentDeployedVersionID}}
+          <a href="/agent_versions/{{.CurrentDeployedVersionID}}/configure">v{{.CurrentDeployedVersionNum}}</a>
+        {{else}}
+          —
+        {{end}}
+      </dd>
+    </div>
+  </dl>
+</section>
+
+<h2 class="section-title">Versions</h2>
 <table class="data-table">
   <thead>
     <tr>
       <th class="col-version">Version</th>
       <th class="col-status">Status</th>
       <th class="col-date">Created</th>
-      <th class="col-actions">Actions</th>
     </tr>
   </thead>
   <tbody>
     {{range .Versions}}
     {{$href := printf "/agent_versions/%s/configure" .Version.ID}}
-    <tr>
+    <tr class="clickable" onclick="location.href=this.dataset.href" data-href="{{$href}}">
       <td class="col-version {{if gt .VersionNum 1}}old{{end}}">
         <a class="agent-link" href="{{$href}}">v{{.VersionNum}}</a>
       </td>
       <td class="col-status"><span class="badge badge-{{.Version.Status | statusClass}}">{{.Version.Status}}</span></td>
       <td class="col-date">{{.Version.CreatedAt.Format "Jan 2, 2006"}}</td>
-      <td class="col-actions">
-        {{if eq .Version.Status "READY"}}
-          <button class="btn-small"
-                  hx-get="/agents/{{$.AgentID}}/deploy/confirm?version_id={{.Version.ID}}"
-                  hx-target="body" hx-swap="beforeend">Deploy</button>
-        {{else if eq .Version.Status "DEPLOYED"}}
-          <button class="btn-small btn-danger"
-                  hx-get="/agents/{{$.AgentID}}/undeploy/confirm"
-                  hx-target="body" hx-swap="beforeend">Undeploy</button>
-        {{end}}
-      </td>
     </tr>
     {{end}}
   </tbody>

--- a/open-bbcd/web/templates/agent-versions.html
+++ b/open-bbcd/web/templates/agent-versions.html
@@ -1,37 +1,46 @@
 {{define "content"}}
 <a href="/agents/ui" class="wizard-back">← Back to Agents</a>
 
-<section class="agent-header-card">
-  <header class="agent-header-top">
-    <h1>{{.Name}}</h1>
-    <div class="agent-header-actions">
-      {{if .DiscoveryFilePath}}
-        <a href="/agents/{{.AgentID}}/discovery"
-           class="btn-secondary">Download discovery</a>
-      {{end}}
+<div class="page-header">
+  <h1>{{.Name}}</h1>
+  <div class="page-header-actions">
+    {{if .DiscoveryFilePath}}
+      <a href="/agents/{{.AgentID}}/discovery" class="btn-secondary">Download discovery</a>
+    {{end}}
+    {{if .CurrentDeployedVersionID}}
+      <button class="btn-secondary btn-danger"
+              hx-get="/agents/{{.AgentID}}/undeploy/confirm"
+              hx-target="body" hx-swap="beforeend">Undeploy</button>
+    {{end}}
+  </div>
+</div>
+
+{{if .Description}}
+<p class="agent-subtitle">{{.Description}}</p>
+{{end}}
+
+<dl class="agent-meta">
+  <div class="agent-meta-item">
+    <dt>Created</dt>
+    <dd>{{.CreatedAt.Format "Jan 2, 2006"}}</dd>
+  </div>
+  {{if .DiscoveryFilePath}}
+  <div class="agent-meta-item">
+    <dt>Discovery file</dt>
+    <dd><code>{{.DiscoveryFilePath}}</code></dd>
+  </div>
+  {{end}}
+  <div class="agent-meta-item">
+    <dt>Currently deployed</dt>
+    <dd>
       {{if .CurrentDeployedVersionID}}
-        <button class="btn-secondary btn-danger"
-                hx-get="/agents/{{.AgentID}}/undeploy/confirm"
-                hx-target="body" hx-swap="beforeend">Undeploy</button>
+        <a href="/agent_versions/{{.CurrentDeployedVersionID}}/configure">v{{.CurrentDeployedVersionNum}}</a>
+      {{else}}
+        —
       {{end}}
-    </div>
-  </header>
-  {{if .Description}}<p class="agent-header-desc">{{.Description}}</p>{{end}}
-  <dl class="agent-header-meta">
-    <div><dt>Created</dt><dd>{{.CreatedAt.Format "Jan 2, 2006"}}</dd></div>
-    {{if .DiscoveryFilePath}}<div><dt>Discovery file</dt><dd><code>{{.DiscoveryFilePath}}</code></dd></div>{{end}}
-    <div>
-      <dt>Currently deployed</dt>
-      <dd>
-        {{if .CurrentDeployedVersionID}}
-          <a href="/agent_versions/{{.CurrentDeployedVersionID}}/configure">v{{.CurrentDeployedVersionNum}}</a>
-        {{else}}
-          —
-        {{end}}
-      </dd>
-    </div>
-  </dl>
-</section>
+    </dd>
+  </div>
+</dl>
 
 <h2 class="section-title">Versions</h2>
 <table class="data-table">

--- a/open-bbcd/web/templates/configurator/finalize.html
+++ b/open-bbcd/web/templates/configurator/finalize.html
@@ -33,7 +33,7 @@
 
   <form method="POST" action="/agent_versions/{{.VersionID}}/finalize" class="config-finalize-form">
     <button type="submit" class="btn-primary">Yes, finalize →</button>
-    <a href="/agent_versions/{{.VersionID}}/configure/flows" class="btn-secondary">Cancel</a>
+    <a href="/agent_versions/{{.VersionID}}/configure/architecture/flows" class="btn-secondary">Cancel</a>
   </form>
 </div>
 {{end}}

--- a/open-bbcd/web/templates/configurator/layout.html
+++ b/open-bbcd/web/templates/configurator/layout.html
@@ -22,21 +22,29 @@
   </div>
 
   <nav class="config-tabs">
-    <a href="/agent_versions/{{.VersionID}}/configure/flows"
-       class="config-tab {{if eq .Tab "flows"}}active{{end}}">Flows</a>
-    <a href="/agent_versions/{{.VersionID}}/configure/skills"
-       class="config-tab {{if eq .Tab "skills"}}active{{end}}">Skills</a>
-    <a href="/agent_versions/{{.VersionID}}/configure/capabilities"
-       class="config-tab {{if eq .Tab "capabilities"}}active{{end}}">Capabilities</a>
     {{if .ReadOnly}}
     <a href="/agent_versions/{{.VersionID}}/configure/inputs"
        class="config-tab {{if eq .Tab "inputs"}}active{{end}}">Inputs</a>
-    {{else}}
+    {{end}}
+    <a href="/agent_versions/{{.VersionID}}/configure/architecture/flows"
+       class="config-tab {{if eq .Tab "architecture"}}active{{end}}">Architecture</a>
+    {{if not .ReadOnly}}
     <span class="config-spacer"></span>
     <a href="/agent_versions/{{.VersionID}}/configure/finalize"
        class="config-tab {{if eq .Tab "finalize"}}active{{end}}">Finalize →</a>
     {{end}}
   </nav>
+
+  {{if eq .Tab "architecture"}}
+  <nav class="config-subtabs">
+    <a href="/agent_versions/{{.VersionID}}/configure/architecture/flows"
+       class="config-subtab {{if eq .SubTab "flows"}}active{{end}}">Flows</a>
+    <a href="/agent_versions/{{.VersionID}}/configure/architecture/skills"
+       class="config-subtab {{if eq .SubTab "skills"}}active{{end}}">Skills</a>
+    <a href="/agent_versions/{{.VersionID}}/configure/architecture/capabilities"
+       class="config-subtab {{if eq .SubTab "capabilities"}}active{{end}}">Capabilities</a>
+  </nav>
+  {{end}}
 
   {{if .ReadOnly}}
   <div class="config-banner config-banner-readonly">

--- a/open-bbcd/web/templates/configurator/layout.html
+++ b/open-bbcd/web/templates/configurator/layout.html
@@ -17,6 +17,11 @@
           style="opacity:0.4;cursor:not-allowed"
           title="No bundle generated for this version yet">Run</button>
       {{end}}
+      {{if eq .AgentStatus "READY"}}
+        <button class="btn-primary"
+                hx-get="/agents/{{.AgentID}}/deploy/confirm?version_id={{.VersionID}}"
+                hx-target="body" hx-swap="beforeend">Deploy</button>
+      {{end}}
     </div>
     {{end}}
   </div>

--- a/open-bbcd/web/templates/configurator/layout.html
+++ b/open-bbcd/web/templates/configurator/layout.html
@@ -21,6 +21,10 @@
         <button class="btn-primary"
                 hx-get="/agents/{{.AgentID}}/deploy/confirm?version_id={{.VersionID}}"
                 hx-target="body" hx-swap="beforeend">Deploy</button>
+      {{else if eq .AgentStatus "DEPLOYED"}}
+        <button class="btn-secondary btn-danger"
+                hx-get="/agents/{{.AgentID}}/undeploy/confirm"
+                hx-target="body" hx-swap="beforeend">Undeploy</button>
       {{end}}
     </div>
     {{end}}

--- a/open-bbcd/web/templates/configurator/layout.html
+++ b/open-bbcd/web/templates/configurator/layout.html
@@ -33,6 +33,10 @@
     {{end}}
     <a href="/agent_versions/{{.VersionID}}/configure/architecture/flows"
        class="config-tab {{if eq .Tab "architecture"}}active{{end}}">Architecture</a>
+    {{if .ReadOnly}}
+    <a href="/agent_versions/{{.VersionID}}/configure/prompts"
+       class="config-tab {{if eq .Tab "prompts"}}active{{end}}">Prompts</a>
+    {{end}}
     {{if not .ReadOnly}}
     <span class="config-spacer"></span>
     <a href="/agent_versions/{{.VersionID}}/configure/finalize"

--- a/open-bbcd/web/templates/configurator/partials.html
+++ b/open-bbcd/web/templates/configurator/partials.html
@@ -3,13 +3,13 @@
   <input type="checkbox" class="config-list-row-toggle"
          {{if .Flow.Included}}checked{{end}}
          {{if .ReadOnly}}disabled{{else}}
-         hx-post="/agent_versions/{{.VersionID}}/configure/flows/{{.Flow.ID}}/included"
+         hx-post="/agent_versions/{{.VersionID}}/configure/architecture/flows/{{.Flow.ID}}/included"
          hx-trigger="change"
          hx-vals='js:{included: event.target.checked}'
          hx-target="#flow-row-{{.Flow.ID}}"
          hx-swap="outerHTML"
          {{end}}>
-  <a href="/agent_versions/{{.VersionID}}/configure/flows/{{.Flow.ID}}" class="config-list-row-link">
+  <a href="/agent_versions/{{.VersionID}}/configure/architecture/flows/{{.Flow.ID}}" class="config-list-row-link">
     <span class="config-list-row-name">{{.Flow.ID}}</span>
     <span class="config-list-row-meta">{{workflowNodeCount .Flow.Workflow}} nodes</span>
   </a>
@@ -73,7 +73,7 @@
 
 {{define "skill_row"}}
 <div id="skill-row-{{.Skill.ID}}">
-  <a href="/agent_versions/{{.VersionID}}/configure/skills/{{.Skill.ID}}"
+  <a href="/agent_versions/{{.VersionID}}/configure/architecture/skills/{{.Skill.ID}}"
      class="config-list-row {{if and .SelectedID (eq .SelectedID .Skill.ID)}}selected{{end}}">
     <span class="config-list-row-name">{{.Skill.ID}}</span>
     <span class="config-list-row-meta">
@@ -145,7 +145,7 @@
 
   <form class="config-form {{if .ReadOnly}}config-form-readonly{{end}}"
         {{if not .ReadOnly}}
-        hx-post="/agent_versions/{{.VersionID}}/configure/skills/{{.Skill.ID}}"
+        hx-post="/agent_versions/{{.VersionID}}/configure/architecture/skills/{{.Skill.ID}}"
         hx-target="closest .config-detail"
         hx-swap="outerHTML"
         hx-indicator=".config-form-saved"
@@ -163,7 +163,7 @@
       {{if eq .Skill.Origin "custom"}}
       <button type="button"
               class="btn-secondary danger-button"
-              hx-delete="/agent_versions/{{.VersionID}}/configure/skills/{{.Skill.ID}}"
+              hx-delete="/agent_versions/{{.VersionID}}/configure/architecture/skills/{{.Skill.ID}}"
               hx-target="#skill-row-{{.Skill.ID}}"
               hx-swap="delete"
               hx-confirm="Delete this custom skill?">Delete</button>
@@ -188,7 +188,7 @@
   <p class="config-detail-id">A new id will be generated from the name.</p>
 
   <form class="config-form"
-        hx-post="/agent_versions/{{.VersionID}}/configure/skills"
+        hx-post="/agent_versions/{{.VersionID}}/configure/architecture/skills"
         hx-target="#skill-list-rows"
         hx-swap="beforeend"
         hx-indicator=".config-form-saved">
@@ -206,7 +206,7 @@
 {{end}}
 
 {{define "capability_row"}}
-<a href="/agent_versions/{{.VersionID}}/configure/capabilities/{{.Cap.Name}}"
+<a href="/agent_versions/{{.VersionID}}/configure/architecture/capabilities/{{.Cap.Name}}"
    class="config-list-row {{if and .SelectedID (eq .SelectedID .Cap.Name)}}selected{{end}}">
   <span class="config-list-row-name">{{.Cap.Name}}</span>
   <span class="config-list-row-meta"><span class="muted">{{len .Cap.Tools}} tools</span></span>

--- a/open-bbcd/web/templates/configurator/prompts.html
+++ b/open-bbcd/web/templates/configurator/prompts.html
@@ -1,0 +1,25 @@
+{{define "tab_content"}}
+<div class="prompts-tab">
+  {{if or .MainPrompt .SkillPrompts}}
+    {{if .MainPrompt}}
+    <section class="prompt-block">
+      <h2>Main prompt</h2>
+      <pre class="prompt-pre">{{.MainPrompt}}</pre>
+    </section>
+    {{end}}
+    {{if .SkillPrompts}}
+    <section class="prompt-skills">
+      <h2>Skill prompts</h2>
+      {{range .SkillPrompts}}
+      <details class="prompt-skill">
+        <summary><strong>{{.Name}}</strong>{{if .Description}} — {{.Description}}{{end}}</summary>
+        <pre class="prompt-pre">{{.Prompt}}</pre>
+      </details>
+      {{end}}
+    </section>
+    {{end}}
+  {{else}}
+    <p class="empty-state">No bundle has been generated for this version yet.</p>
+  {{end}}
+</div>
+{{end}}

--- a/open-bbcd/web/templates/configurator/skills.html
+++ b/open-bbcd/web/templates/configurator/skills.html
@@ -11,7 +11,7 @@
     </div>
     {{if not .ReadOnly}}
     <button class="skill-add-trigger"
-            hx-get="/agent_versions/{{.VersionID}}/configure/skills/new"
+            hx-get="/agent_versions/{{.VersionID}}/configure/architecture/skills/new"
             hx-target=".config-detail-pane"
             hx-swap="innerHTML">+ Add skill</button>
     {{end}}

--- a/open-bbcd/web/templates/layout.html
+++ b/open-bbcd/web/templates/layout.html
@@ -94,10 +94,6 @@
     .agent-header-meta a{color:#79c0ff;text-decoration:none}
     .agent-header-meta a:hover{text-decoration:underline}
     .section-title{margin:24px 0 8px 0;font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:#a8b3c1;font-weight:600}
-    .config-subtabs{display:flex;gap:4px;margin:8px 0 16px 0;border-bottom:1px solid #2d333b}
-    .config-subtab{padding:6px 12px;font-size:13px;color:#a8b3c1;border-bottom:2px solid transparent;text-decoration:none}
-    .config-subtab.active{color:#f0f6fc;border-bottom-color:#79c0ff}
-    .config-subtab:hover{color:#f0f6fc}
   </style>
   <link rel="stylesheet" href="/static/drawflow.min.css">
   <link rel="stylesheet" href="/static/configurator.css">

--- a/open-bbcd/web/templates/layout.html
+++ b/open-bbcd/web/templates/layout.html
@@ -84,7 +84,7 @@
     #form-body{min-height:200px}
     .agent-header-card{border:1px solid #2d333b;border-radius:8px;padding:16px 20px;background:#161b22;margin-bottom:24px}
     .agent-header-top{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:8px}
-    .agent-header-top h1{margin:0;font-size:22px;color:#f0f6fc}
+    .agent-header-top h1{margin:0;font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f0f6fc}
     .agent-header-actions{display:flex;gap:8px;align-items:center}
     .agent-header-desc{color:#a8b3c1;margin:0 0 12px 0}
     .agent-header-meta{display:flex;flex-wrap:wrap;gap:24px;margin:0}

--- a/open-bbcd/web/templates/layout.html
+++ b/open-bbcd/web/templates/layout.html
@@ -82,6 +82,18 @@
     .field-file-wrap input{margin-top:8px}
     .wizard-nav{display:flex;justify-content:space-between;align-items:center;margin-top:20px}
     #form-body{min-height:200px}
+    .agent-header-card{border:1px solid #2d333b;border-radius:8px;padding:16px 20px;background:#161b22;margin-bottom:24px}
+    .agent-header-top{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:8px}
+    .agent-header-top h1{margin:0;font-size:22px;color:#f0f6fc}
+    .agent-header-actions{display:flex;gap:8px;align-items:center}
+    .agent-header-desc{color:#a8b3c1;margin:0 0 12px 0}
+    .agent-header-meta{display:flex;flex-wrap:wrap;gap:24px;margin:0}
+    .agent-header-meta dt{font-size:12px;color:#a8b3c1;text-transform:uppercase;letter-spacing:.04em}
+    .agent-header-meta dd{margin:2px 0 0 0;font-size:14px;color:#f0f6fc}
+    .agent-header-meta code{background:#1c2230;padding:1px 6px;border-radius:4px;color:#c2a4ff;font-size:13px}
+    .agent-header-meta a{color:#79c0ff;text-decoration:none}
+    .agent-header-meta a:hover{text-decoration:underline}
+    .section-title{margin:24px 0 8px 0;font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:#a8b3c1;font-weight:600}
   </style>
   <link rel="stylesheet" href="/static/drawflow.min.css">
   <link rel="stylesheet" href="/static/configurator.css">

--- a/open-bbcd/web/templates/layout.html
+++ b/open-bbcd/web/templates/layout.html
@@ -82,18 +82,15 @@
     .field-file-wrap input{margin-top:8px}
     .wizard-nav{display:flex;justify-content:space-between;align-items:center;margin-top:20px}
     #form-body{min-height:200px}
-    .agent-header-card{border:1px solid #2d333b;border-radius:8px;padding:16px 20px;background:#161b22;margin-bottom:24px}
-    .agent-header-top{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:8px}
-    .agent-header-top h1{margin:0;font-size:22px;font-weight:600;letter-spacing:-.02em;color:#f0f6fc}
-    .agent-header-actions{display:flex;gap:8px;align-items:center}
-    .agent-header-desc{color:#a8b3c1;margin:0 0 12px 0}
-    .agent-header-meta{display:flex;flex-wrap:wrap;gap:24px;margin:0}
-    .agent-header-meta dt{font-size:12px;color:#a8b3c1;text-transform:uppercase;letter-spacing:.04em}
-    .agent-header-meta dd{margin:2px 0 0 0;font-size:14px;color:#f0f6fc}
-    .agent-header-meta code{background:#1c2230;padding:1px 6px;border-radius:4px;color:#c2a4ff;font-size:13px}
-    .agent-header-meta a{color:#79c0ff;text-decoration:none}
-    .agent-header-meta a:hover{text-decoration:underline}
-    .section-title{margin:24px 0 8px 0;font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:#a8b3c1;font-weight:600}
+    .page-header-actions{display:flex;gap:8px;align-items:center}
+    .agent-subtitle{color:#a8b3c1;font-size:14px;margin:-16px 0 24px 0}
+    .agent-meta{display:flex;flex-wrap:wrap;gap:36px;margin:0 0 28px 0;padding-bottom:20px;border-bottom:1px solid #2d333b}
+    .agent-meta-item dt{font-size:11px;color:#a8b3c1;text-transform:uppercase;letter-spacing:.06em;margin-bottom:4px;font-weight:600}
+    .agent-meta-item dd{margin:0;font-size:14px;color:#f0f6fc}
+    .agent-meta-item code{background:#1c2230;padding:2px 8px;border-radius:4px;color:#c2a4ff;font-size:13px}
+    .agent-meta-item a{color:#79c0ff;text-decoration:none}
+    .agent-meta-item a:hover{text-decoration:underline}
+    .section-title{margin:8px 0 12px 0;font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:#a8b3c1;font-weight:600}
   </style>
   <link rel="stylesheet" href="/static/drawflow.min.css">
   <link rel="stylesheet" href="/static/configurator.css">

--- a/open-bbcd/web/templates/layout.html
+++ b/open-bbcd/web/templates/layout.html
@@ -94,6 +94,10 @@
     .agent-header-meta a{color:#79c0ff;text-decoration:none}
     .agent-header-meta a:hover{text-decoration:underline}
     .section-title{margin:24px 0 8px 0;font-size:12px;text-transform:uppercase;letter-spacing:.04em;color:#a8b3c1;font-weight:600}
+    .config-subtabs{display:flex;gap:4px;margin:8px 0 16px 0;border-bottom:1px solid #2d333b}
+    .config-subtab{padding:6px 12px;font-size:13px;color:#a8b3c1;border-bottom:2px solid transparent;text-decoration:none}
+    .config-subtab.active{color:#f0f6fc;border-bottom-color:#79c0ff}
+    .config-subtab:hover{color:#f0f6fc}
   </style>
   <link rel="stylesheet" href="/static/drawflow.min.css">
   <link rel="stylesheet" href="/static/configurator.css">


### PR DESCRIPTION
## Summary

BO frontend reshaped around the agents/agent_versions split landed in #29:

- **Agent detail page** — flow-layout header with name, optional description, and a metadata row (Created / Discovery file / Currently deployed). `Download discovery` and `Undeploy` buttons live in the top-right. Versions table loses its Actions column.
- **Version detail page** — tabs restructured to `Inputs · Architecture · Prompts · [Finalize]`. Architecture is a parent tab with sub-tabs `Flows · Skills · Capabilities` (today's three tabs nested). New read-only **Prompts** tab renders the compiled bundle's `main_prompt` + per-skill prompts. **Deploy** button moved into the header for READY versions; **Undeploy** lives both on the agent header and on the version detail header for DEPLOYED versions.
- **Inputs tab trimmed** to the 4 per-version fields (`scope`, `should_do`, `should_not_do`, `business_domain`) — name and discovery file already live on the agent header.
- **New endpoint** — `GET /agents/{agent_id}/discovery` streams the discovery zip via a new `storage.Storage.Open` method (`Content-Disposition: attachment; filename="<agent_id>.zip"`).
- **Routes restructured** — flow/skill/capability routes (incl. POST/DELETE) now under `/configure/architecture/*`. Legacy GET paths 301 to the new shape so existing bookmarks survive.
- **Storage interface** gained `Open(ctx, key) (io.ReadCloser, error)` with `ErrNotFound` + `ErrInvalidKey` sentinels and a path-traversal guard.

Pure presentation/routing change — no DB migration.

Spec: `docs/superpowers/specs/2026-06-16-bo-frontend-agent-version-redesign-design.md`
Plan: `docs/superpowers/plans/2026-06-16-bo-frontend-agent-version-redesign.md`

## Commits

Built task-by-task with two-stage review (spec compliance + code quality) per commit. 16 commits in narrative order: storage primitive → header data → header card → discovery download → architecture restructure → deploy/undeploy buttons → trim Inputs → Prompts tab → polish.

## Test plan

- [ ] `make test` is green (verified locally — 0 failures, race detector on)
- [ ] Agents list (`/agents/ui`) renders unchanged
- [ ] Agent detail (`/agents/ui?agent=<id>`): name, description, metadata row, Download discovery, Undeploy (when something is deployed), Versions table (no Actions column)
- [ ] Discovery download link returns the zip with a sensible filename
- [ ] Version detail tabs: `Inputs · Architecture · Prompts` for read-only; `Architecture · Finalize→` for INITIALIZING
- [ ] Architecture sub-tabs switch between Flows / Skills / Capabilities
- [ ] Old bookmark `/agent_versions/{id}/configure/flows` 301s to `/configure/architecture/flows`
- [ ] Inputs tab shows only the 4 per-version fields
- [ ] Prompts tab renders main + per-skill prompts on READY bundles; empty state on NULL/malformed bundle
- [ ] READY version detail header shows Deploy button; DEPLOYED shows Undeploy; DRAFT/INITIALIZING/TRAINING show neither

🤖 Generated with [Claude Code](https://claude.com/claude-code)